### PR TITLE
Display the error details

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -114,7 +114,7 @@ var invoke = exports.invoke = function invoke(http_method, path, data, http_opti
 
             if (!err && (res.statusCode < 200 || res.statusCode >= 300)) {
                 err = new Error('Response Status : ' + res.statusCode);
-                err.response = response;
+                err.response = JSON.stringify(response);
                 err.httpStatusCode = res.statusCode;
                 response = null;
             }


### PR DESCRIPTION
Instead of 
```
response:
   { name: 'BUSINESS_VALIDATION_ERROR',
     details: [ [Object] ],
     message: 'Validation Error.',
     information_link: 'https://developer.paypal.com/webapps/developer/docs/api/#BUSINESS_VALIDATION_ERROR',
     debug_id: '9d79bd5181d01',
     httpStatusCode: 400 },
  httpStatusCode: 400 }

```

We should have

```
{ [Error: Response Status : 400]
  response: '{"name":"BUSINESS_VALIDATION_ERROR","details":[{"field":"validation_failure","issue":"Plan not in active state."}],"message":"Validation Error.","information_link":"https://developer.paypal.com/webapps/developer/docs/api/#BUSINESS_VALIDATION_ERROR","debug_id":"4c60c14308539","httpStatusCode":400}',
  httpStatusCode: 400 }

```