### PR TITLE
fix API methods like PayPal.openIdConnect.userinfo.get()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -85,7 +85,8 @@ var invoke = exports.invoke = function invoke(http_method, path, data, http_opti
                 //Set response to be parsed JSON object if data received is json
                 //expect that content-type header has application/json when it
                 //returns data
-                if (res.headers['content-type'] === "application/json") {
+                if (typeof res.headers['content-type'] === "string" &&
+                    res.headers['content-type'].match(/^application\/json(?:;.*)?$/) !== null) {
                     response = JSON.parse(response);
                 }
                 //Set response to an empty object if no data was received


### PR DESCRIPTION
fix API methods like PayPal.openIdConnect.userinfo.get() where PayPal returns an HTTP 'Content-Type' header with the value 'application/json;charset=UTF-8' instead of just 'application/json'.