### PR TITLE
Update web-hook verify function to support PayPal-provided hashing algorithm

### DIFF
--- a/lib/resources/Notification.js
+++ b/lib/resources/Notification.js
@@ -38,17 +38,74 @@ function webhookEvent() {
     var baseURL = '/v1/notifications/webhooks-events/';
     var operations = ['list', 'get'];
 
-    function verifyPayload(key, msg, hash) {
-        return crypto.createVerify('sha1WithRSAEncryption')
+    function verifyPayload(key, msg, hash, hashAlgo) {
+        hashAlgo = hashAlgo || 'sha256WithRSAEncryption';
+
+        return crypto.createVerify(hashAlgo)
             .update(msg)
             .verify(key, hash, 'base64');
     }
 
-    function verify(certURL, transmissionId, timeStamp, webhookId, eventBody, ppTransmissionSig, cb) {
+    /**
+     * @param {Object} headers from request
+     * @param {String} raw body of request
+     * @param {String} webhook id
+     * @param {Function} callback function
+     */
+    function verify(headers, body, webhookId, callback) {
+        // In an effort not to break existing applications, accept old arguments temporarily
+        if(arguments.length > 4) {
+            return verifyLegacy.apply(this, arguments);
+        }
+
+        if(typeof headers !== 'object') {
+            return callback(new Error("headers is not an object"), false);
+        }
+
+        // Normalizes headers
+        Object.keys(headers).forEach(function(header) {
+            headers[header.toUpperCase()] = headers[header];
+        });
+
+        // Convert PayPal's hashing algorithm to one Node supports
+        // (assuming SHA is used indefinitely)
+        if(typeof headers['PAYPAL-AUTH-ALGO'] === 'string') {
+            headers['PAYPAL-AUTH-ALGO'] = headers['PAYPAL-AUTH-ALGO']
+                                           .replace(/^SHA/, 'sha')
+                                           .replace(/withRSA$/, 'WithRSAEncryption');
+        }
+
+        https.get(headers['PAYPAL-CERT-URL'], function (res) {
+            var cert = '';
+            res.on('error', function (e) {
+                console.log('PayPal-Node-SDK: problem with cert dl - ' + e.message);
+                callback(e, null);
+            });
+            res.on('data', function (chunk) {
+                cert += chunk;
+            });
+            res.on('end', function () {
+                var err = null;
+                var response = false;
+                try {
+                    var expectedSignature = headers['PAYPAL-TRANSMISSION-ID'] + "|" + headers['PAYPAL-TRANSMISSION-TIME'] + "|" + webhookId + "|" + crc32.unsigned(body);
+                    response = verifyPayload(cert, expectedSignature, headers['PAYPAL-TRANSMISSION-SIG'], headers['PAYPAL-AUTH-ALGO']);
+                } catch (e) {
+                    err = new Error("Error verifying webhook payload.");
+                }
+                callback(err, response);
+            });
+        });
+    }
+
+    function verifyLegacy(certURL, transmissionId, timeStamp, webhookId, eventBody, ppTransmissionSig, cb) {
+        // Emit a warning that the arguments have changed
+        console.log('PayPal-Node-SDK: Webhook verify arguments have changed. Please check the latest documentation.');
+
         https.get(certURL, function (res) {
             var cert = '';
             res.on('error', function (e) {
-                console.log('problem with request' + e.message);
+                console.log('PayPal-Node-SDK: problem with cert dl - ' + e.message);
                 cb(e, null);
             });
             res.on('data', function (chunk) {
@@ -67,6 +124,8 @@ function webhookEvent() {
             });
         });
     }
+
+
 
     var ret = {
         baseURL: baseURL,


### PR DESCRIPTION
(couldn't get webhook simulator working, so it needs tests updated [tested on live data])

Function changed to accept an object of request headers, which makes passing in data easier. Legacy support added to prevent immediate breaking of old code.

Referencing #68 