### PR TITLE
set withCredentials: false

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -61,6 +61,7 @@ var invoke = exports.invoke = function invoke(http_method, path, data, http_opti
         }
 
         http_options.headers['User-Agent'] = configuration.userAgent;
+        http_options.withCredentials = false;
     }
 
     var req = client.request(http_options);


### PR DESCRIPTION
Fixes #94. Otherwise `http-browserify` sets it to true here: https://github.com/substack/http-browserify/blob/master/lib/request.js#18. Some configurations break with that setting and it's not needed.