### PR TITLE
correlation-id rename to client-metadata-id

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -128,7 +128,11 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
         client.invoke(http_method, path, data, http_options, cb);
     }
 
-    if (http_options.correlation_id) {
+    // correlation-id is deprecated in favor of client-metadata-id
+    if (http_options.client_metadata_id) {
+        http_options.headers['Paypal-Client-Metadata-Id'] = http_options.client_metadata_id;
+    }
+    else if (http_options.correlation_id) {
         http_options.headers['Paypal-Client-Metadata-Id'] = http_options.correlation_id;
     }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -129,7 +129,6 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
     }
 
     if (http_options.correlation_id) {
-        http_options.headers['Paypal-Application-Correlation-Id'] = http_options.correlation_id;
         http_options.headers['Paypal-Client-Metadata-Id'] = http_options.correlation_id;
     }
 

--- a/samples/payment/create_future_payment.js
+++ b/samples/payment/create_future_payment.js
@@ -23,7 +23,7 @@ paypal.generateToken(auth_code, function (error, rt) {
         console.log(rt);
         var refresh_token = rt;
 
-        var future_payment_config = {'correlation_id': 'Correlation ID from mobile sdk', 'refresh_token': refresh_token};
+        var future_payment_config = {'client_metadata_id': 'Client Metadata ID from mobile sdk', 'refresh_token': refresh_token};
 
         //Set up payment details
         var create_payment_json = {


### PR DESCRIPTION
'Application-Correlation-ID' was renamed to 'Client-Metadata-ID'. This updates the SDK accordingly.