### PR TITLE
Fix a typo in inline documentation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -123,7 +123,7 @@ var invoke = exports.invoke = function invoke(http_method, path, data, http_opti
             } catch (e) {
                 err = new Error('Invalid JSON Response Received. If the response received is empty, please check' +
                  'the httpStatusCode attribute of error message for 401 or 403. It is possible that the client credentials' +
-                  'are invalid for the environement you are using, be it live or sandbox.');
+                  'are invalid for the environment you are using, be it live or sandbox.');
                 err.error = {
                     name: 'Invalid JSON Response Received, JSON Parse Error.'
                 };


### PR DESCRIPTION
`environement` → `environment`