### PR TITLE
Do not cache access tokens fetched from refresh tokens

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -67,9 +67,11 @@ var generateToken = exports.generateToken = function generateToken(config, cb) {
     client.invoke('POST', '/v1/oauth2/token', payload, http_options, function (err, res) {
         var token = null;
         if (res) {
-            var seconds = new Date().getTime() / 1000;
-            token_persist[config.client_id] = res;
-            token_persist[config.client_id].created_at = seconds;
+            if (!config.authorization_code && !config.refresh_token) {
+                var seconds = new Date().getTime() / 1000;
+                token_persist[config.client_id] = res;
+                token_persist[config.client_id].created_at = seconds;
+            }
 
             if (!config.authorization_code) {
                 token = res.token_type + ' ' + res.access_token;


### PR DESCRIPTION
- The access tokens are being cached when they should not be for one-time
  future payments. Fix #226 