### PR TITLE
HTTP config host precedence order

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -124,7 +124,7 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
     }
 
     //Get host endpoint using mode
-    http_options.host = http_options.host || utils.getDefaultApiEndpoint(http_options.mode) ;
+    http_options.host = http_options.host || utils.getDefaultApiEndpoint(http_options.mode);
 
     function retryInvoke() {
         client.invoke(http_method, path, data, http_options, cb);

--- a/lib/api.js
+++ b/lib/api.js
@@ -15,7 +15,7 @@ var token_persist = {};
  * Set up configuration globally such as client_id and client_secret,
  * by merging user provided configurations otherwise use default settings
  * @param  {Object} options Configuration parameters passed as object
- * @return {undefined}        
+ * @return {undefined}
  */
 var configure = exports.configure = function configure(options) {
     if (options !== undefined && typeof options === 'object') {
@@ -55,7 +55,7 @@ var generateToken = exports.generateToken = function generateToken(config, cb) {
 
     var http_options = {
         schema: config.schema || configuration.default_options.schema,
-        host: utils.getDefaultApiEndpoint(config.mode) || config.host || configuration.default_options.host,
+        host: config.host || utils.getDefaultApiEndpoint(config.mode) || configuration.default_options.host,
         port: config.port || configuration.default_options.port,
         headers: utils.merge({
             'Authorization': basicAuthString,
@@ -124,7 +124,7 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
     }
 
     //Get host endpoint using mode
-    http_options.host = utils.getDefaultApiEndpoint(http_options.mode) || http_options.host;
+    http_options.host = http_options.host || utils.getDefaultApiEndpoint(http_options.mode) ;
 
     function retryInvoke() {
         client.invoke(http_method, path, data, http_options, cb);


### PR DESCRIPTION
Change around the host recognition, to match other cases where the options passed in take precedence over defaults.

Currently the default option for host eclipses any other passed in configuration.