### PR TITLE
add support for using an HTTPS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Continuous integration status:
 
-[![Build Status](https://travis-ci.org/paypal/PayPal-node-SDK.svg?branch=master)](https://travis-ci.org/paypal/PayPal-node-SDK) [![Coverage Status](https://coveralls.io/repos/paypal/PayPal-node-SDK/badge.svg?branch=master)](https://coveralls.io/r/paypal/PayPal-node-SDK?branch=master) 
+[![Build Status](https://travis-ci.org/paypal/PayPal-node-SDK.svg?branch=master)](https://travis-ci.org/paypal/PayPal-node-SDK) [![Coverage Status](https://coveralls.io/repos/paypal/PayPal-node-SDK/badge.svg?branch=master)](https://coveralls.io/r/paypal/PayPal-node-SDK?branch=master)
 
 NPM status:
 
@@ -36,12 +36,13 @@ To write an app using the SDK
     var paypal = require('paypal-rest-sdk');
     ```
   * Create config options, with parameters (mode, client_id, secret).
-
+  * to use an HTTPS proxy (like squid proxy) for all your requests supply a proxy_url parameter.
     ```js
     paypal.configure({
       'mode': 'sandbox', //sandbox or live
       'client_id': 'EBWKjlELKMYqRNQ6sYvFo64FtaRLRR5BdHEESmha49TM',
-      'client_secret': 'EO422dn3gQLgDbuwqTjzrFgFtaRLRR5BdHEESmha49TM'
+      'client_secret': 'EO422dn3gQLgDbuwqTjzrFgFtaRLRR5BdHEESmha49TM',
+      'proxy_url': 'http://127.0.0.1:3128' // only set this if you want to use a proxy
     });
     ```
   * For multiple configuration support, have a look at the [sample](/samples/configuration/multiple_config.js)
@@ -166,5 +167,5 @@ NOCK_OFF=true mocha -t 60000
 ## License
 Code released under [SDK LICENSE](LICENSE)  
 
-## Contributions 
- Pull requests and new issues are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for details. 
+## Contributions
+ Pull requests and new issues are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,7 @@ var querystring = require('querystring');
 var uuid = require('uuid');
 var configuration = require('./configure');
 var semver = require('semver');
+var HttpsProxyAgent = require('https-proxy-agent');
 
 /**
  * Wraps the http client, handles request parameters, populates request headers, handles response
@@ -74,6 +75,14 @@ var invoke = exports.invoke = function invoke(http_method, path, data, http_opti
     //PCI compliance
     if (process.versions !== undefined && process.versions.openssl !== undefined && semver.lt(process.versions.openssl.slice(0, 5), '1.0.1')) {
         console.warn('WARNING: openssl version ' + process.versions.openssl + ' detected. Per PCI Security Council mandate (https://github.com/paypal/TLS-update), you MUST update to the latest security library.');
+    }
+
+    //HTTPS Proxy
+    if (configuration.default_options.proxy_url) {
+        http_options.agent = new HttpsProxyAgent(configuration.default_options.proxy_url);
+
+        // if proxy url is http, port will default to 80, but we need it to be 443, so set it explicitly
+        http_options.port = 443;
     }
 
     var req = client.request(http_options);

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -9,6 +9,7 @@ var default_options = exports.default_options = {
     'schema': 'https',
     'host': 'api.sandbox.paypal.com',
     'port': '',
+    'proxy_url': '',
     'openid_connect_schema': 'https',
     'openid_connect_host': 'api.sandbox.paypal.com',
     'openid_connect_port': '',

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "main": "./index.js",
   "dependencies": {
     "buffer-crc32": "^0.2.3",
+    "https-proxy-agent": "^1.0.0",
     "semver": "^5.0.3",
     "uuid": "^2.0.1"
   },


### PR DESCRIPTION
add support for using an HTTPS proxy for all requests,

- added new dependency `https-proxy-agent` to `package.json`
- added `proxy_url` default param to `lib/configure.js`
- added a check for a supplied `proxy_url` in `lib/client.js`, and if found uses the proxy through `https-proxy-agent`
- updated `README.md` with info on how to use this new `proxy_url` param