### PR TITLE
Promise support

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -120,23 +120,44 @@ var generateToken = exports.generateToken = function generateToken(config, cb) {
     return result;
 };
 
-/* Update authorization header with new token obtained by calling
-generateToken */
+/* Update authorization header with new token obtained by calling generateToken */
 /**
  * Updates http Authorization header to newly created access token
  * @param  {Object}   http_options   Configuration parameters such as authorization code or refresh token
  * @param  {Function}   error_callback
  * @param  {Function} callback
+ * @deprecated
  */
 function updateToken(http_options, error_callback, callback) {
-    generateToken(http_options, function (error, token) {
-        if (error) {
-            error_callback(error, token);
-        } else {
-            http_options.headers.Authorization = token;
-            callback();
-        }
-    });
+    var clientId = http_options.client_id;
+    var status = store.getStatus(clientId);
+
+    function onResolve() {
+        setAuthorizationHeader(http_options, clientId);
+        callback();
+    }
+
+    function onReject(err) {
+        error_callback(err, null);
+    }
+
+    // If the token for this client is not refreshing already, refresh the token
+    if (status !== TOKEN_STATUS.REFRESHING) {
+        store.setStatus(clientId, TOKEN_STATUS.REFRESHING);
+        generateToken(http_options).then(onResolve, onReject);
+    } else {
+        // If the method is invoked more than once (eg. inside an async.parallel call) just queue a new item and wait
+        // for the call in progress to finish to set the token
+        store
+            .getQueue(clientId)
+            .enqueue({http_options: http_options}) // Do not use the http_options object directly
+            .then(onResolve, onReject);
+    }
+}
+
+function setAuthorizationHeader(http_options, clientId) {
+    var tokenInfo = store.getToken(clientId);
+    http_options.headers.Authorization = tokenInfo.token_type + ' ' + tokenInfo.access_token;
 }
 
 /**

--- a/lib/api.js
+++ b/lib/api.js
@@ -8,7 +8,7 @@ var Promise = global.Promise || require('es6-promise');
 var Store = require('./store');
 var TOKEN_STATUS = Store.TOKEN_STATUS;
 
-var INVALID_CLIENT_MESSAGE = 'Invalid client_id and secret. Did you forget to set those?';
+var MISSING_CLIENT_MESSAGE = 'Invalid client_id and secret. Did you forget to set those?';
 
 // Replace token_persist object with a client store to manage tokens, statuses and call queues
 var store = new Store();
@@ -72,6 +72,9 @@ var generateToken = exports.generateToken = function generateToken(config, cb) {
     };
 
     var clientId = config.client_id;
+    if (!clientId) {
+        throw new Error(MISSING_CLIENT_MESSAGE);
+    }
     result = client.invoke('POST', '/v1/oauth2/token', payload, http_options)
         .then(function (res) {
             var token = null;

--- a/lib/api.js
+++ b/lib/api.js
@@ -183,10 +183,6 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
     //Get host endpoint using mode
     http_options.host = http_options.host || utils.getDefaultApiEndpoint(http_options.mode);
 
-    function retryInvoke() {
-        client.invoke(http_method, path, data, http_options, cb);
-    }
-
     // correlation-id is deprecated in favor of client-metadata-id
     if (http_options.client_metadata_id) {
         http_options.headers['Paypal-Client-Metadata-Id'] = http_options.client_metadata_id;
@@ -195,20 +191,109 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
         http_options.headers['Paypal-Client-Metadata-Id'] = http_options.correlation_id;
     }
 
-    // If client_id exists with an unexpired token and a refresh token is not provided, reuse cached token    
-    if (http_options.client_id in token_persist && !utils.checkExpiredToken(token_persist[http_options.client_id]) && !http_options.refresh_token) {
-        http_options.headers.Authorization = "Bearer " + token_persist[http_options.client_id].access_token;
-        client.invoke(http_method, path, data, http_options, function (error, response) {
-            // Don't reprompt already authenticated user for login by updating Authorization header
-            // if token expires
-            if (error && error.httpStatusCode === 401 && http_options.client_id && http_options.headers.Authorization) {
-                http_options.headers.Authorization = null;
-                updateToken(http_options, cb, retryInvoke);
-            } else {
-                cb(error, response);
-            }
+    // Retry call function for callback mode
+    function retryInvoke() {
+        client.invoke(http_method, path, data, http_options, cb);
+    }
+
+    // Checks if the call requires authorization
+    function reauthorize(error) {
+        return error && error.httpStatusCode === 401 && http_options.client_id && http_options.headers.Authorization;
+    }
+
+    // Refresh the token and flush or halt the call queue
+    function refresh(clientId) {
+        var queue = store.getQueue(clientId);
+        return generateToken(http_options)
+            .then(function () {
+                queue.flush();
+            })
+            .catch(function (err) {
+                queue.halt(err);
+                return Promise.reject(err);
+            });
+    }
+
+    // Retry the call but after the token has been refreshed and the call queue is flushing
+    function queueCall(clientId) {
+        return store.getQueue(clientId).enqueue({
+            http_method: http_method,
+            path: path,
+            data: data,
+            http_options: http_options
+        }).then(function (config) {
+            setAuthorizationHeader(http_options, clientId);
+            return client.invoke(config.http_method, config.path, config.data, config.http_options);
         });
+    }
+
+    var clientId = http_options.client_id;
+    // Promises
+    if (!cb) {
+        if (!clientId) {
+            return Promise.reject(new Error(MISSING_CLIENT_MESSAGE));
+        }
+
+        switch (store.getStatus(clientId)) {
+        case TOKEN_STATUS.REFRESHING:
+            // If the token for this clientId is refreshing just add the call to the queue
+            return queueCall(clientId);
+        case TOKEN_STATUS.VALID:
+            // If the token is valid check for expiration before making the call
+            if (!utils.checkExpiredToken(store.getToken(clientId))) {
+                return client
+                    .invoke(http_method, path, data, http_options)
+                    .catch(function (err) {
+                        var promise;
+                        if (reauthorize(err)) {
+                            // If the call fails and:
+                            //   the token can be refreshed add this call to the queue and refresh the token
+                            //   the token is already refreshing(concurrent requests) just queue the call
+                            promise = queueCall(clientId);
+                            if (store.getStatus(clientId) === TOKEN_STATUS.REFRESHING) {
+                                return promise;
+                            }
+                            store.setStatus(clientId, TOKEN_STATUS.REFRESHING);
+                            refresh(clientId);
+                            return promise;
+                        }
+
+                        return Promise.reject(err);
+                    });
+            } else {
+                // If the token is expired refresh it before continuing
+                store.setStatus(clientId, TOKEN_STATUS.REFRESHING);
+                refresh(clientId);
+                return queueCall(clientId);
+            }
+
+        case TOKEN_STATUS.NOT_FOUND:
+            // If no token is stored for this clientId get one first
+            store.setStatus(clientId, TOKEN_STATUS.REFRESHING);
+            refresh(clientId);
+            return queueCall(clientId);
+            break;
+        }
     } else {
-        updateToken(http_options, cb, retryInvoke);
+        // Callbacks
+        if (!clientId) {
+            cb(new Error(MISSING_CLIENT_MESSAGE));
+        }
+        // If client_id exists with an unexpired token and a refresh token is not provided, reuse cached token
+        if (store.getStatus(clientId) === TOKEN_STATUS.VALID && !utils.checkExpiredToken(store.getToken(clientId)) && !http_options.refresh_token) {
+            setAuthorizationHeader(http_options, clientId);
+            client.invoke(http_method, path, data, http_options, function (error, response) {
+                // Don't reprompt already authenticated user for login by updating Authorization header
+                // if token expires
+                if (reauthorize(error)) {
+                    http_options.headers.Authorization = null;
+                    updateToken(http_options, cb, retryInvoke);
+                } else {
+                    cb(error, response);
+                }
+            });
+        } else {
+            updateToken(http_options, cb, retryInvoke);
+        }
     }
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,12 +4,14 @@
 var client = require('./client');
 var utils = require('./utils');
 var configuration = require('./configure');
+var Promise = global.Promise || require('es6-promise');
+var Store = require('./store');
+var TOKEN_STATUS = Store.TOKEN_STATUS;
 
-/**
- * token_persist client id to access token cache, used to reduce access token round trips
- * @type {Object}
- */
-var token_persist = {};
+var INVALID_CLIENT_MESSAGE = 'Invalid client_id and secret. Did you forget to set those?';
+
+// Replace token_persist object with a client store to manage tokens, statuses and call queues
+var store = new Store();
 
 /**
  * Set up configuration globally such as client_id and client_secret,
@@ -38,6 +40,7 @@ var configure = exports.configure = function configure(options) {
  * @return {String}          Access token or Refresh token
  */
 var generateToken = exports.generateToken = function generateToken(config, cb) {
+    var result;
 
     if (typeof config === "function") {
         cb = config;
@@ -68,24 +71,50 @@ var generateToken = exports.generateToken = function generateToken(config, cb) {
         }, configuration.default_options.headers, true)
     };
 
-    client.invoke('POST', '/v1/oauth2/token', payload, http_options, function (err, res) {
-        var token = null;
-        if (res) {
-            if (!config.authorization_code && !config.refresh_token) {
-                var seconds = new Date().getTime() / 1000;
-                token_persist[config.client_id] = res;
-                token_persist[config.client_id].created_at = seconds;
+    var clientId = config.client_id;
+    result = client.invoke('POST', '/v1/oauth2/token', payload, http_options)
+        .then(function (res) {
+            var token = null;
+            if (res) {
+                if (!config.authorization_code && !config.refresh_token) {
+                    var seconds = new Date().getTime() / 1000;
+                    res.created_at = seconds;
+                    store.setToken(clientId, res);
+                    store.setStatus(clientId, TOKEN_STATUS.VALID);
+                }
+
+                if (!config.authorization_code) {
+                    token = res.token_type + ' ' + res.access_token;
+                }
+                else {
+                    token = res.refresh_token;
+                }
             }
 
-            if (!config.authorization_code) {
-                token = res.token_type + ' ' + res.access_token;
+            // Pass the token using promises or callbacks
+            if (!cb) {
+                return token;
             }
-            else {
-                token = res.refresh_token;
+            cb(null, token);
+        })
+        .catch(function (err) {
+            // Clear the token for the client
+            store.setToken(clientId, null);
+            store.setStatus(clientId, TOKEN_STATUS.NOT_FOUND);
+            // If no callback is provided propagate the error in the promise chain
+            if (!cb) {
+                return Promise.reject(err);
             }
-        }
-        cb(err, token);
-    });
+            // Otherwise use the callback to signal the error
+            cb(err, null);
+        });
+
+    // If a callback was provided don't return the promise so users have to use one way or the other but not both
+    if (cb) {
+        result = undefined;
+    }
+    // Otherwise return the promise to be handled by user code
+    return result;
 };
 
 /* Update authorization header with new token obtained by calling
@@ -93,8 +122,8 @@ generateToken */
 /**
  * Updates http Authorization header to newly created access token
  * @param  {Object}   http_options   Configuration parameters such as authorization code or refresh token
- * @param  {Function}   error_callback 
- * @param  {Function} callback       
+ * @param  {Function}   error_callback
+ * @param  {Function} callback
  */
 function updateToken(http_options, error_callback, callback) {
     generateToken(http_options, function (error, token) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -266,13 +266,12 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
                 refresh(clientId);
                 return queueCall(clientId);
             }
-
+            break;
         case TOKEN_STATUS.NOT_FOUND:
             // If no token is stored for this clientId get one first
             store.setStatus(clientId, TOKEN_STATUS.REFRESHING);
             refresh(clientId);
             return queueCall(clientId);
-            break;
         }
     } else {
         // Callbacks

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,10 @@ var querystring = require('querystring');
 var configuration = require('./configure');
 var semver = require('semver');
 
+var pify = require('pify');
+// Required for node < 0.12
+var Promise = global.Promise || require('es6-promise');
+
 /**
  * Wraps the http client, handles request parameters, populates request headers, handles response
  * @param  {String}   http_method        HTTP Method GET/POST
@@ -16,133 +20,146 @@ var semver = require('semver');
  * @param  {Function} cb                 [description]
  */
 var invoke = exports.invoke = function invoke(http_method, path, data, http_options_param, cb) {
-    var client = (http_options_param.schema === 'http') ? http : https;
 
-    var request_data = data;
+    function makeRequest(callback) {
+        var client = (http_options_param.schema === 'http') ? http : https;
 
-    if (http_method === 'GET') {
-        //format object parameters into GET request query string
-        if (typeof request_data !== 'string') {
-            request_data = querystring.stringify(request_data);
-        }
-        if (request_data) {
-            path = path + "?" + request_data;
-            request_data = "";
-        }
-    } else if (typeof request_data !== 'string') {
-        request_data = JSON.stringify(request_data);
-    }
+        var request_data = data;
 
-    var http_options = {};
-
-    if (http_options_param) {
-
-        http_options = JSON.parse(JSON.stringify(http_options_param));
-
-        if (!http_options.headers) {
-            http_options.headers = {};
-        }
-        http_options.path = path;
-        http_options.method = http_method;
-        if (request_data) {
-            http_options.headers['Content-Length'] = Buffer.byteLength(request_data, 'utf-8');
+        if (http_method === 'GET') {
+            //format object parameters into GET request query string
+            if (typeof request_data !== 'string') {
+                request_data = querystring.stringify(request_data);
+            }
+            if (request_data) {
+                path = path + "?" + request_data;
+                request_data = "";
+            }
+        } else if (typeof request_data !== 'string') {
+            request_data = JSON.stringify(request_data);
         }
 
-        if (!http_options.headers.Accept) {
-            http_options.headers.Accept = 'application/json';
+        var http_options = {};
+
+        if (http_options_param) {
+
+            http_options = JSON.parse(JSON.stringify(http_options_param));
+
+            if (!http_options.headers) {
+                http_options.headers = {};
+            }
+            http_options.path = path;
+            http_options.method = http_method;
+            if (request_data) {
+                http_options.headers['Content-Length'] = Buffer.byteLength(request_data, 'utf-8');
+            }
+
+            if (!http_options.headers.Accept) {
+                http_options.headers.Accept = 'application/json';
+            }
+
+            if (!http_options.headers['Content-Type']) {
+                http_options.headers['Content-Type'] = 'application/json';
+            }
+
+            http_options.headers['User-Agent'] = configuration.userAgent;
+            http_options.withCredentials = false;
         }
 
-        if (!http_options.headers['Content-Type']) {
-            http_options.headers['Content-Type'] = 'application/json';
+        // Enable full request response logging in development/non-production environment only
+        if (configuration.default_options.mode !== 'live' && process.env.NODE_ENV === 'development') {
+            console.dir(JSON.stringify(http_options.headers));
+            console.dir(request_data);
         }
 
-        http_options.headers['User-Agent'] = configuration.userAgent;
-        http_options.withCredentials = false;
-    }
-
-    // Enable full request response logging in development/non-production environment only
-    if (configuration.default_options.mode !== 'live' && process.env.NODE_ENV === 'development') {
-        console.dir(JSON.stringify(http_options.headers));
-        console.dir(request_data);
-    }
-
-    //PCI compliance
-    if (process.versions !== undefined && process.versions.openssl !== undefined && semver.lt(process.versions.openssl.slice(0, 5), '1.0.1')) {
-        console.warn('WARNING: openssl version ' + process.versions.openssl + ' detected. Per PCI Security Council mandate (https://github.com/paypal/TLS-update), you MUST update to the latest security library.');
-    }
-
-    var req = client.request(http_options);
-    req.on('error', function (e) {
-        console.log('problem with request: ' + e.message);
-        cb(e, null);
-    });
-
-    req.on('response', function (res) {
-        var response = '';
-        //do not setEndcoding with browserify
-        if (res.setEncoding) {
-            res.setEncoding('utf8');
+        //PCI compliance
+        if (process.versions !== undefined && process.versions.openssl !== undefined && semver.lt(process.versions.openssl.slice(0, 5), '1.0.1')) {
+            console.warn('WARNING: openssl version ' + process.versions.openssl + ' detected. Per PCI Security Council mandate (https://github.com/paypal/TLS-update), you MUST update to the latest security library.');
         }
 
-        res.on('data', function (chunk) {
-            response += chunk;
+        var req = client.request(http_options);
+        req.on('error', function (e) {
+            console.log('problem with request: ' + e.message);
+            callback(e, null);
         });
 
-        res.on('end', function () {
-            var err = null;
+        req.on('response', function (res) {
+            var response = '';
+            //do not setEndcoding with browserify
+            if (res.setEncoding) {
+                res.setEncoding('utf8');
+            }
 
-            try {
-                //TURN NODE_ENV to development to get access to paypal-debug-id
-                //for questions to merchant technical services.
-                if (res.headers['paypal-debug-id'] !== undefined && process.env.NODE_ENV === 'development') {
-                    console.log('paypal-debug-id: ' + res.headers['paypal-debug-id']);
+            res.on('data', function (chunk) {
+                response += chunk;
+            });
 
-                    if (configuration.default_options.mode !== 'live') {
-                        console.dir(JSON.stringify(res.headers));
-                        console.dir(response);
+            res.on('end', function () {
+                var err = null;
+
+                try {
+                    //TURN NODE_ENV to development to get access to paypal-debug-id
+                    //for questions to merchant technical services.
+                    if (res.headers['paypal-debug-id'] !== undefined && process.env.NODE_ENV === 'development') {
+                        console.log('paypal-debug-id: ' + res.headers['paypal-debug-id']);
+
+                        if (configuration.default_options.mode !== 'live') {
+                            console.dir(JSON.stringify(res.headers));
+                            console.dir(response);
+                        }
                     }
+
+                    // Set response to an empty object if no data was received
+                    if (response.trim() === '') {
+                        response = {};
+                    } else if (typeof res.headers['content-type'] === "string" &&
+                        res.headers['content-type'].match(/^application\/json(?:;.*)?$/) !== null) {
+                        // Set response to be parsed JSON object if data received is json
+                        // expect that content-type header has application/json when it
+                        // returns data
+                        response = JSON.parse(response);
+                    }
+                    response.httpStatusCode = res.statusCode;
+                } catch (e) {
+                    err = new Error('Invalid JSON Response Received. If the response received is empty, please check' +
+                        'the httpStatusCode attribute of error message for 401 or 403. It is possible that the client credentials' +
+                        'are invalid for the environment you are using, be it live or sandbox.');
+                    err.error = {
+                        name: 'Invalid JSON Response Received, JSON Parse Error.'
+                    };
+                    err.response = response;
+                    err.httpStatusCode = res.statusCode;
+                    response = null;
                 }
 
-                // Set response to an empty object if no data was received
-                if (response.trim() === '') {
-                    response = {};
-                } else if (typeof res.headers['content-type'] === "string" &&
-                    res.headers['content-type'].match(/^application\/json(?:;.*)?$/) !== null) {
-                    // Set response to be parsed JSON object if data received is json
-                    // expect that content-type header has application/json when it
-                    // returns data
-                    response = JSON.parse(response);
+                if (!err && (res.statusCode < 200 || res.statusCode >= 300)) {
+                    err = new Error('Response Status : ' + res.statusCode);
+                    // response contains the full json description of the error
+                    // that PayPal returns and information link
+                    err.response = response;
+                    if (process.env.NODE_ENV === 'development') {
+                        err.response_stringified = JSON.stringify(response);
+                    }
+                    err.httpStatusCode = res.statusCode;
+                    response = null;
                 }
-                response.httpStatusCode = res.statusCode;
-            } catch (e) {
-                err = new Error('Invalid JSON Response Received. If the response received is empty, please check' +
-                 'the httpStatusCode attribute of error message for 401 or 403. It is possible that the client credentials' +
-                  'are invalid for the environment you are using, be it live or sandbox.');
-                err.error = {
-                    name: 'Invalid JSON Response Received, JSON Parse Error.'
-                };
-                err.response = response;
-                err.httpStatusCode = res.statusCode;
-                response = null;
-            }
-
-            if (!err && (res.statusCode < 200 || res.statusCode >= 300)) {
-                err = new Error('Response Status : ' + res.statusCode);
-                // response contains the full json description of the error
-                // that PayPal returns and information link
-                err.response = response;
-                if (process.env.NODE_ENV === 'development') {
-                    err.response_stringified = JSON.stringify(response);
-                }
-                err.httpStatusCode = res.statusCode;
-                response = null;
-            }
-            cb(err, response);
+                callback(err, response);
+            });
         });
-    });
 
-    if (request_data) {
-        req.write(request_data);
+        if (request_data) {
+            req.write(request_data);
+        }
+        req.end();
     }
-    req.end();
+
+    // If no callback is provided wrap the http call in a promise
+    if (!cb) {
+        return pify(makeRequest, {promiseModule: Promise})();
+    }
+
+    // If a callback was provided just pass the results of the call
+    makeRequest(function (err, response) {
+        cb(err, response);
+    });
 };

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -24,36 +24,36 @@ function mixin(destObject, operations) {
  */
 var restFunctions = {
     create: function create(data, config, cb) {
-        api.executeHttp('POST', this.baseURL, data, config, cb);
+        return api.executeHttp('POST', this.baseURL, data, config, cb);
     },
     get: function get(id, config, cb) {
-        api.executeHttp('GET', this.baseURL + id, {}, config, cb);
+        return api.executeHttp('GET', this.baseURL + id, {}, config, cb);
     },
     list: function list(data, config, cb) {
         if (typeof data === 'function') {
             config = data;
             data = {};
         }
-        api.executeHttp('GET', this.baseURL, data, config, cb);
+        return api.executeHttp('GET', this.baseURL, data, config, cb);
     },
     del: function del(id, config, cb) {
-        api.executeHttp('DELETE', this.baseURL + id, {}, config, cb);
+        return api.executeHttp('DELETE', this.baseURL + id, {}, config, cb);
     },
     //provided for compatibility with 0.* versions
     delete: function del(id, config, cb) {
-        api.executeHttp('DELETE', this.baseURL + id, {}, config, cb);
+        return api.executeHttp('DELETE', this.baseURL + id, {}, config, cb);
     },
     capture: function capture(id, data, config, cb) {
-        api.executeHttp('POST', this.baseURL + id + '/capture', data, config, cb);
+        return api.executeHttp('POST', this.baseURL + id + '/capture', data, config, cb);
     },
     refund: function refund(id, data, config, cb) {
-        api.executeHttp('POST', this.baseURL + id + '/refund', data, config, cb);
+        return api.executeHttp('POST', this.baseURL + id + '/refund', data, config, cb);
     },
     update: function update(id, data, config, cb) {
-        api.executeHttp('PATCH', this.baseURL + id, data, config, cb);
+        return api.executeHttp('PATCH', this.baseURL + id, data, config, cb);
     },
     cancel: function cancel(id, data, config, cb) {
-        api.executeHttp('POST', this.baseURL + id + '/cancel', data, config, cb);
+        return api.executeHttp('POST', this.baseURL + id + '/cancel', data, config, cb);
     }
 };
 

--- a/lib/paypal-rest-sdk.js
+++ b/lib/paypal-rest-sdk.js
@@ -11,7 +11,7 @@ module.exports = function () {
     }
 
     function generateToken(config, cb) {
-        api.generateToken(config, cb);
+        return api.generateToken(config, cb);
     }
 
     return {

--- a/lib/resources/Authorization.js
+++ b/lib/resources/Authorization.js
@@ -22,7 +22,7 @@ function authorization() {
          * @return {Object}          Authorization object
          */
         void: function voidAuthorization(id, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/void', {}, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/void', {}, config, cb);
         },
         /**
          * Reauthorize a PayPal account payment
@@ -33,8 +33,8 @@ function authorization() {
          * @return {}          
          */
         reauthorize: function reauthorize(id, data, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/reauthorize', data, config, cb);
-        },
+            return api.executeHttp('POST', this.baseURL + id + '/reauthorize', data, config, cb);
+        }
     };
     ret = generate.mixin(ret, operations);
     return ret;

--- a/lib/resources/BillingAgreement.js
+++ b/lib/resources/BillingAgreement.js
@@ -27,7 +27,7 @@ function billingAgreement() {
             "start_date": start_date,
             "end_date": end_date
         };
-        api.executeHttp('GET', baseURL + id + '/transactions', date_range, config, cb);
+        return api.executeHttp('GET', baseURL + id + '/transactions', date_range, config, cb);
     }
 
     /**
@@ -39,7 +39,7 @@ function billingAgreement() {
      * @return {}          Returns the HTTP status of 204 if the call is successful
      */
     function billBalance(id, data, config, cb) {
-        api.executeHttp('POST', baseURL + id + '/bill-balance', data, config, cb);
+        return api.executeHttp('POST', baseURL + id + '/bill-balance', data, config, cb);
     }
 
     /**
@@ -51,7 +51,7 @@ function billingAgreement() {
      * @return {}          Returns the HTTP status of 204 if the call is successful
      */
     function setBalance(id, data, config, cb) {
-        api.executeHttp('POST', baseURL + id + '/set-balance', data, config, cb);
+        return api.executeHttp('POST', baseURL + id + '/set-balance', data, config, cb);
     }
 
     var ret = {
@@ -70,7 +70,7 @@ function billingAgreement() {
                 cb = data;
                 data = {};
             }
-            api.executeHttp('POST', this.baseURL + token + '/agreement-execute', data, config, cb);
+            return api.executeHttp('POST', this.baseURL + token + '/agreement-execute', data, config, cb);
         },
         /**
          * Changes agreement state to suspended, can be reactivated unlike cancelling agreement
@@ -81,7 +81,7 @@ function billingAgreement() {
          * @return {}          Returns the HTTP status of 204 if the call is successful
          */
         suspend: function suspend(id, data, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/suspend', data, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/suspend', data, config, cb);
         },
         /**
          * Reactivate a suspended agreement
@@ -92,7 +92,7 @@ function billingAgreement() {
          * @return {}          Returns the HTTP status of 204 if the call is successful
          */
         reactivate: function reactivate(id, data, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/re-activate', data, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/re-activate', data, config, cb);
         },
         billBalance: billBalance,
         setBalance: setBalance,

--- a/lib/resources/BillingPlan.js
+++ b/lib/resources/BillingPlan.js
@@ -32,7 +32,7 @@ function billingPlan() {
                     }
                 }
             ];
-            api.executeHttp('PATCH', this.baseURL + id, activate_attributes, config, cb);
+            return api.executeHttp('PATCH', this.baseURL + id, activate_attributes, config, cb);
         }
     };
     ret = generate.mixin(ret, operations);

--- a/lib/resources/Invoice.js
+++ b/lib/resources/Invoice.js
@@ -16,31 +16,31 @@ function invoice() {
     var ret = {
         baseURL: baseURL,
         search: function search(data, config, cb) {
-            api.executeHttp('POST', '/v1/invoicing/search', data, config, cb);
+            return api.executeHttp('POST', '/v1/invoicing/search', data, config, cb);
         },
         update: function update(id, data, config, cb) {
-            api.executeHttp('PUT', this.baseURL + id, data, config, cb);
+            return api.executeHttp('PUT', this.baseURL + id, data, config, cb);
         },
         send: function send(id, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/send', {}, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/send', {}, config, cb);
         },
         remind: function remind(id, data, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/remind', data, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/remind', data, config, cb);
         },
         recordPayment: function recordPayment(id, data, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/record-payment', data, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/record-payment', data, config, cb);
         },
         recordRefund: function recordRefund(id, data, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/record-refund', data, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/record-refund', data, config, cb);
         },
         deleteExternalPayment: function deleteExternalPayment(invoiceId, transactionId, config, cb) {
-            api.executeHttp('DELETE', this.baseURL + invoiceId + '/payment-records/' + transactionId, {}, config, cb);
+            return api.executeHttp('DELETE', this.baseURL + invoiceId + '/payment-records/' + transactionId, {}, config, cb);
         },
         deleteExternalRefund: function deleteExternalRefund(invoiceId, transactionId, config, cb) {
-            api.executeHttp('DELETE', this.baseURL + invoiceId + '/refund-records/' + transactionId, {}, config, cb);
+            return api.executeHttp('DELETE', this.baseURL + invoiceId + '/refund-records/' + transactionId, {}, config, cb);
         },
         generateNumber: function generateNumber(config, cb) {
-            api.executeHttp("POST", this.baseURL + '/next-invoice-number', {}, config, cb);
+            return api.executeHttp("POST", this.baseURL + '/next-invoice-number', {}, config, cb);
         },
         /* Specify invoice ID to get a QR code corresponding to the invoice */
         qrCode: function qrCode(id, height, width, config, cb) {
@@ -48,7 +48,7 @@ function invoice() {
                 "height": height,
                 "width": width
             };
-            api.executeHttp('GET', this.baseURL + id + '/qr-code', image_attributes, config, cb);
+            return api.executeHttp('GET', this.baseURL + id + '/qr-code', image_attributes, config, cb);
         }
     };
     ret = generate.mixin(ret, operations);

--- a/lib/resources/InvoiceTemplate.js
+++ b/lib/resources/InvoiceTemplate.js
@@ -11,7 +11,7 @@ function invoiceTemplate() {
     var ret = {
         baseURL: baseURL,
         update: function update(id, data, config, cb) {
-            api.executeHttp('PUT', this.baseURL + id, data, config, cb);
+            return api.executeHttp('PUT', this.baseURL + id, data, config, cb);
         }
     };
 

--- a/lib/resources/Notification.js
+++ b/lib/resources/Notification.js
@@ -18,10 +18,10 @@ function webhook() {
     var ret = {
         baseURL: baseURL,
         replace: function replace(id, data, config, cb) {
-            api.executeHttp('PATCH', this.baseURL + id, data, config, cb);
+            return api.executeHttp('PATCH', this.baseURL + id, data, config, cb);
         },
         eventTypes: function eventTypes(id, config, cb) {
-            api.executeHttp('GET', this.baseURL + id + '/event-types', {}, config, cb);
+            return api.executeHttp('GET', this.baseURL + id + '/event-types', {}, config, cb);
         }
     };
     ret = generate.mixin(ret, operations);
@@ -128,7 +128,7 @@ function webhookEvent() {
             'webhook_event': webhookEventBody
         };
 
-        api.executeHttp('POST', '/v1/notifications/verify-webhook-signature', payload, callback);
+        return api.executeHttp('POST', '/v1/notifications/verify-webhook-signature', payload, callback);
     }
 
     function verifyLegacy(certURL, transmissionId, timeStamp, webhookId, eventBody, ppTransmissionSig, cb) {
@@ -168,7 +168,7 @@ function webhookEvent() {
         verify: verify,
         getAndVerify: getAndVerify,
         resend: function resend(id, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/resend', {}, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/resend', {}, config, cb);
         }
     };
     ret = generate.mixin(ret, operations);

--- a/lib/resources/OpenIdConnect.js
+++ b/lib/resources/OpenIdConnect.js
@@ -28,7 +28,7 @@ function openIdConnectRequest(path, data, config, cb) {
         http_options.headers.Authorization = 'Basic ' + new Buffer(data.client_id + ':' + data.client_secret).toString('base64');
     }
 
-    client.invoke('POST', path, querystring.stringify(data), http_options, cb);
+    return client.invoke('POST', path, querystring.stringify(data), http_options, cb);
 }
 
 /**
@@ -125,7 +125,7 @@ function tokenInfoRequest(data, config, cb) {
         'client_secret': getClientSecret(config)
     }, data);
 
-    openIdConnectRequest('/v1/identity/openidconnect/tokenservice', data, config, cb);
+    return openIdConnectRequest('/v1/identity/openidconnect/tokenservice', data, config, cb);
 }
 
 /**
@@ -150,7 +150,7 @@ function userInfoRequest(data, config, cb) {
         'schema': 'openid'
     }, data);
 
-    openIdConnectRequest('/v1/identity/openidconnect/userinfo', data, config, cb);
+    return openIdConnectRequest('/v1/identity/openidconnect/userinfo', data, config, cb);
 }
 
 /**
@@ -165,14 +165,14 @@ function openIdConnect() {
                     data = { 'code': data };
                 }
                 data.grant_type = 'authorization_code';
-                tokenInfoRequest(data, config, cb);
+                return tokenInfoRequest(data, config, cb);
             },
             refresh: function (data, config, cb) {
                 if (typeof data === 'string') {
                     data = { 'refresh_token': data };
                 }
                 data.grant_type = 'refresh_token';
-                tokenInfoRequest(data, config, cb);
+                return tokenInfoRequest(data, config, cb);
             }
         },
         authorizeUrl: authorizeUrl,

--- a/lib/resources/Order.js
+++ b/lib/resources/Order.js
@@ -22,7 +22,7 @@ function order() {
          * @return {Object}          Order object, with state set to voided
          */
         void: function voidOrder(id, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/do-void', {}, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/do-void', {}, config, cb);
         },
         /**
          * Authorize an order
@@ -33,8 +33,8 @@ function order() {
          * @return {Object}          Authorization object
          */
         authorize: function authorize(id, data, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/authorize', data, config, cb);
-        },
+            return api.executeHttp('POST', this.baseURL + id + '/authorize', data, config, cb);
+        }
     };
     ret = generate.mixin(ret, operations);
     return ret;

--- a/lib/resources/Payment.js
+++ b/lib/resources/Payment.js
@@ -23,7 +23,7 @@ function payment() {
          * @return {Object}          Payment object for completed PayPal payment
          */
         execute: function execute(id, data, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/execute', data, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/execute', data, config, cb);
         }
     };
     ret = generate.mixin(ret, operations);

--- a/lib/resources/Payout.js
+++ b/lib/resources/Payout.js
@@ -25,7 +25,7 @@ function payout() {
         create: function create(data, sync_mode, config, cb) {
             cb = (typeof sync_mode === 'function') ? sync_mode : cb;
             sync_mode = (typeof sync_mode === 'string' && sync_mode === 'true') ? 'true' : 'false';
-            api.executeHttp('POST', this.baseURL + "?" + "sync_mode=" + sync_mode, data, config, cb);
+            return api.executeHttp('POST', this.baseURL + "?" + "sync_mode=" + sync_mode, data, config, cb);
         }
     };
     ret = generate.mixin(ret, operations);

--- a/lib/resources/PayoutItem.js
+++ b/lib/resources/PayoutItem.js
@@ -25,7 +25,7 @@ function payoutItem() {
          * @return {Object}          Payout item details object with transaction status of RETURNED
          */
         cancel: function cancel(id, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/cancel', {}, config, cb);
+            return api.executeHttp('POST', this.baseURL + id + '/cancel', {}, config, cb);
         }
     };
     ret = generate.mixin(ret, operations);

--- a/lib/resources/WebProfile.js
+++ b/lib/resources/WebProfile.js
@@ -26,7 +26,7 @@ function webProfile() {
          * @return {}          Returns the HTTP status of 204 if the call is successful
          */
         update: function update(id, data, config, cb) {
-            api.executeHttp('PUT', this.baseURL + id, data, config, cb);
+            return api.executeHttp('PUT', this.baseURL + id, data, config, cb);
         },
         /**
          * Partially update a web experience profile
@@ -37,8 +37,8 @@ function webProfile() {
          * @return {}          Returns the HTTP status of 204 if the call is successful
          */
         replace: function replace(id, data, config, cb) {
-            api.executeHttp('PATCH', this.baseURL + id, data, config, cb);
-        },
+            return api.executeHttp('PATCH', this.baseURL + id, data, config, cb);
+        }
     };
     ret = generate.mixin(ret, operations);
     return ret;

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -1,6 +1,9 @@
 /* Copyright 2015-2016 PayPal, Inc. */
 'use strict';
 
+// The status constants are exported as a static property of the store
+// because the NOT_FOUND status is required as a default value for clients
+// otherwise the constants could be moved closer to its usage
 var TOKEN_STATUS = {
     NOT_FOUND: 0,
     VALID: 1,
@@ -9,10 +12,20 @@ var TOKEN_STATUS = {
 
 var Queue = require('./queue');
 
+/**
+ * @class Store
+ * @classdesc A data store that holds for each client token, token status and a call queue
+ * @constructor
+ */
 function Store() {
     this.store = {};
 }
 
+/**
+ * Initializes the store for a client with default values if is not already initialized
+ * @param {String} clientId The client id to initialize
+ * @private
+ */
 Store.prototype._init = function _init(clientId) {
     if (!this.store[clientId]) {
         this.store[clientId] = {
@@ -23,38 +36,81 @@ Store.prototype._init = function _init(clientId) {
     }
 };
 
+/**
+ * Sets a value in a property of the store for a client initializing the key first if necessary
+ * @param {String} clientId The client id to store the value
+ * @param {String} prop The property to set
+ * @param {*} data The value to set
+ * @private
+ */
 Store.prototype._set = function (clientId, prop, data) {
     this._init(clientId);
     var item = this.store[clientId];
     item[prop] = data;
 };
+
+/**
+ * Retrieves a property of the store for a client initializing the key first if necessary
+ * @param {String} clientId The client id to store the value
+ * @param {String} prop The property to retrieve
+ * @return {*} The value stored in the property
+ * @private
+ */
 Store.prototype._get = function (clientId, prop) {
     this._init(clientId);
     return this.store[clientId][prop];
 };
 
+/**
+ * Returns the token of a given client
+ * @param {String} clientId The client id to retrieve the token
+ * @return {Object} The token
+ */
 Store.prototype.getToken = function getToken(clientId) {
     return this._get(clientId, 'token');
 };
 
+/**
+ * Sets the token of a client
+ * @param {String} clientId The client id to set the token
+ * @param {Object} token The token to store
+ */
 Store.prototype.setToken = function setToken(clientId, token) {
     this._set(clientId, 'token', token);
 };
 
-Store.prototype.getStatus = function getToken(clientId) {
+/**
+ * Returns the token status of a client
+ * @param {String} clientId The client id to retrieve the token
+ * @return {Number} The token status code
+ */
+Store.prototype.getStatus = function getStatus(clientId) {
     return this._get(clientId, 'status');
 };
 
-
+/**
+ * Sets the token status of a client
+ * @param {String} clientId The client id to set the status
+ * @param {Number} status The token status code
+ */
 Store.prototype.setStatus = function setStatus(clientId, status) {
     this._set(clientId, 'status', status);
 };
 
+/**
+ * Returns the call queue of a client
+ * @param {String} clientId The client id to retrieve the queue
+ * @return {Queue} The call queue
+ */
 Store.prototype.getQueue = function getQueue(clientId) {
     return this._get(clientId, 'queue');
 };
 
-
+/**
+ * Token status constants
+ * @static
+ * @type {{NOT_FOUND: number, VALID: number, REFRESHING: number}}
+ */
 Store.TOKEN_STATUS = TOKEN_STATUS;
 
 module.exports = exports = Store;

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -1,0 +1,60 @@
+/* Copyright 2015-2016 PayPal, Inc. */
+'use strict';
+
+var TOKEN_STATUS = {
+    NOT_FOUND: 0,
+    VALID: 1,
+    REFRESHING: 2
+};
+
+var Queue = require('./queue');
+
+function Store() {
+    this.store = {};
+}
+
+Store.prototype._init = function _init(clientId) {
+    if (!this.store[clientId]) {
+        this.store[clientId] = {
+            token: null,
+            status: TOKEN_STATUS.NOT_FOUND,
+            queue: new Queue()
+        };
+    }
+};
+
+Store.prototype._set = function (clientId, prop, data) {
+    this._init(clientId);
+    var item = this.store[clientId];
+    item[prop] = data;
+};
+Store.prototype._get = function (clientId, prop) {
+    this._init(clientId);
+    return this.store[clientId][prop];
+};
+
+Store.prototype.getToken = function getToken(clientId) {
+    return this._get(clientId, 'token');
+};
+
+Store.prototype.setToken = function setToken(clientId, token) {
+    this._set(clientId, 'token', token);
+};
+
+Store.prototype.getStatus = function getToken(clientId) {
+    return this._get(clientId, 'status');
+};
+
+
+Store.prototype.setStatus = function setStatus(clientId, status) {
+    this._set(clientId, 'status', status);
+};
+
+Store.prototype.getQueue = function getQueue(clientId) {
+    return this._get(clientId, 'queue');
+};
+
+
+Store.TOKEN_STATUS = TOKEN_STATUS;
+
+module.exports = exports = Store;

--- a/lib/store/queue.js
+++ b/lib/store/queue.js
@@ -1,0 +1,77 @@
+/* Copyright 2015-2016 PayPal, Inc. */
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+var Promise = global.Promise || require('es6-promise');
+
+function Queue() {
+    EventEmitter.call(this);
+    this.setMaxListeners(0);
+    this._queue = [];
+}
+
+util.inherits(Queue, EventEmitter);
+
+Queue.prototype.enqueue = function enqueue(config) {
+    var self = this;
+
+    var promise = new Promise(function (resolve, reject) {
+        var handler = function _handler(cnf, err) {
+            if (config === cnf) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(config);
+                }
+                self.removeListener('dequeue', _handler);
+            }
+        };
+        self.on('dequeue', handler);
+    });
+
+    self._queue.push(config);
+    self.emit('enqueue', config);
+    return promise;
+};
+
+Queue.prototype.dequeue = function dequeue() {
+    var config = this._queue.shift();
+    if (config) {
+        this.emit('dequeue', config);
+    }
+    return config;
+};
+
+Queue.prototype.peek = function peek() {
+    return this._queue[0];
+};
+
+Queue.prototype.size = function size() {
+    return this._queue.length;
+};
+
+Queue.prototype._clear = function _clear(err) {
+    var length = this.size();
+    var config;
+    for (var i = 0; i < length; i++) {
+        config = this._queue[i];
+        if (err) {
+            this.emit('dequeue', config, err);
+        } else {
+            this.emit('dequeue', config);
+        }
+    }
+    this._queue = [];
+    this.emit(err ? 'halt' : 'flush');
+};
+
+Queue.prototype.flush = function flush() {
+    this._clear();
+};
+
+Queue.prototype.halt = function halt(err) {
+    this._clear(err);
+};
+
+module.exports = exports = Queue;

--- a/lib/store/queue.js
+++ b/lib/store/queue.js
@@ -5,6 +5,12 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var Promise = global.Promise || require('es6-promise');
 
+/**
+ * @class Queue
+ * @classdesc A queue implementation with promise support
+ * @extends EventEmitter
+ * @constructor
+ */
 function Queue() {
     EventEmitter.call(this);
     this.setMaxListeners(0);
@@ -13,6 +19,12 @@ function Queue() {
 
 util.inherits(Queue, EventEmitter);
 
+/**
+ * Add an item to the end of the queue
+ * @param {Object} config The item to store
+ * @return {Promise} A promise that resolves with the item (or rejects with an error) when the item is removed from the queue
+ * @fires Queue#enqueue
+ */
 Queue.prototype.enqueue = function enqueue(config) {
     var self = this;
 
@@ -35,6 +47,11 @@ Queue.prototype.enqueue = function enqueue(config) {
     return promise;
 };
 
+/**
+ * Removes the first item from the queue
+ * @return {Object} The stored item
+ * @fires Queue#dequeue
+ */
 Queue.prototype.dequeue = function dequeue() {
     var config = this._queue.shift();
     if (config) {
@@ -43,17 +60,36 @@ Queue.prototype.dequeue = function dequeue() {
     return config;
 };
 
+/**
+ * Gets the first item from the queue without removing it
+ * @return {Object} The stored item
+ */
 Queue.prototype.peek = function peek() {
     return this._queue[0];
 };
 
+/**
+ * The size of the queue
+ * @return {Number} The number of items in the queue
+ */
 Queue.prototype.size = function size() {
     return this._queue.length;
 };
 
+/**
+ * Synchronously removes all items in the queue
+ * @param {Error} [err] If the error is provided all items rejects instead of resolving
+ * @private
+ * @fires Queue#dequeue
+ * @fires Queue#flush
+ * @fires Queue#halt
+ */
 Queue.prototype._clear = function _clear(err) {
+    // Clearing the queue synchronously is required to avoid new items to be added while it clears
     var length = this.size();
     var config;
+    // Although is possible to call dequeue once for every item doing so is slower
+    // than emitting the event and clearing the queue afterwards
     for (var i = 0; i < length; i++) {
         config = this._queue[i];
         if (err) {
@@ -66,10 +102,20 @@ Queue.prototype._clear = function _clear(err) {
     this.emit(err ? 'halt' : 'flush');
 };
 
+/**
+ * Clears the queue resolving all promises with their items
+ * @fires Queue#dequeue
+ * @fires Queue#flush
+ */
 Queue.prototype.flush = function flush() {
     this._clear();
 };
 
+/**
+ * Clears the queue rejecting all promises with an error
+ * @fires Queue#dequeue
+ * @fires Queue#halt
+ */
 Queue.prototype.halt = function halt(err) {
     this._clear(err);
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "buffer-crc32": "^0.2.3",
     "es6-promise": "^4.1.1",
-    "pify": "^3.0.0",
+    "pify": "^2.3.0",
     "semver": "^5.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "main": "./index.js",
   "dependencies": {
     "buffer-crc32": "^0.2.3",
+    "es6-promise": "^4.1.1",
+    "pify": "^3.0.0",
     "semver": "^5.0.3"
   },
   "devDependencies": {
@@ -38,7 +40,9 @@
     "jsdoc": "^3.3.0-beta1",
     "mocha": "~1.18.2",
     "mocha-lcov-reporter": "0.0.1",
-    "nock": "0.36.2"
+    "nock": "0.36.2",
+    "sinon": "^2.4.1",
+    "sinon-chai": "^2.12.0"
   },
   "config": {
     "blanket": {

--- a/test/client_store.js
+++ b/test/client_store.js
@@ -1,0 +1,120 @@
+"use strict";
+
+var chai = require('chai'),
+    expect = chai.expect,
+    should = chai.should();
+
+var EventEmitter = require('events').EventEmitter;
+
+var Store = require('../lib/store');
+var Queue = require('../lib/store/queue');
+
+describe('Client store', function () {
+
+    describe('Store functionality', function () {
+        var store = new Store();
+
+        // TODO: Add sinon to test emitters
+        it('should have methods to manipulate tokens, tokens status and call queues', function () {
+            expect(store).to.respondTo('getToken');
+            expect(store).to.respondTo('setToken');
+            expect(store).to.respondTo('getStatus');
+            expect(store).to.respondTo('setStatus');
+            expect(store).to.respondTo('getQueue');
+        });
+
+        it('should expose token status constants', function () {
+            expect(Store).to.have.property('TOKEN_STATUS');
+            expect(Store.TOKEN_STATUS).to.have.keys('NOT_FOUND', 'REFRESHING', 'VALID');
+        });
+
+        it('should set a token for a client id without explicit initialization of the client', function () {
+            function setToken() {
+                store.setToken('clientId1', {token: 'abc'});
+            }
+            expect(setToken).not.to.throw();
+        });
+
+        it('should initialize a null value for a client token on access', function () {
+            var token = store.getToken('clientId2');
+            expect(token).to.be.null;
+        });
+
+        it('should initialize a default token status of NOT_FOUND', function () {
+            var status = store.getStatus('clientId3');
+            expect(status).to.equal(Store.TOKEN_STATUS.NOT_FOUND);
+        });
+
+        it('should set a token status without explicit initialization', function () {
+            function setStatus() {
+                store.setStatus('clientId4', Store.TOKEN_STATUS.REFRESHING);
+            }
+            expect(setStatus).not.to.throw();
+        });
+    });
+
+    describe('Call queues', function () {
+        var store = new Store();
+
+        it('should return a new queue per client without explicit initialization', function () {
+            var queue;
+            function getQueue() {
+                queue = store.getQueue('clientId1');
+            }
+
+            expect(getQueue).not.to.throw();
+            expect(queue).to.be.an.instanceOf(EventEmitter);
+            expect(queue).to.be.an.instanceOf(Queue);
+            expect(queue).to.respondTo('enqueue');
+            expect(queue).to.respondTo('dequeue');
+            expect(queue).to.respondTo('peek');
+            expect(queue).to.respondTo('size');
+            expect(queue).to.respondTo('flush');
+            expect(queue).to.respondTo('halt');
+        });
+
+        it('should return a promise when a new item is enqueued', function () {
+            var queue = store.getQueue('clientId2');
+            // .to.be.a('promise') does not work in this version of chai
+            expect(queue.enqueue({foo: 'bar'})).to.respondTo('then');
+        });
+
+        it('should keep track of the number of items in the queue', function () {
+            var queue = store.getQueue('clientId3');
+            queue.enqueue({foo: 'bar'});
+            expect(queue.size()).to.equal(1);
+        });
+
+        it('should allow to peek the first item in the queue without removing it', function () {
+            var queue = store.getQueue('clientId4');
+            queue.enqueue({foo: 'bar'});
+            queue.enqueue({bar: 'baz'});
+            // Call twice to check is the same value
+            var value1 = queue.peek();
+            var value2 = queue.peek();
+            expect(value1).to.have.property('foo', 'bar');
+            expect(value2).to.have.property('foo', 'bar');
+            expect(queue.size()).to.equal(2);
+        });
+
+        it('should allow to remove an item from the queue', function () {
+            var queue = store.getQueue('clientId5');
+            queue.enqueue({foo: 'bar'});
+            queue.enqueue({bar: 'baz'});
+            var value = queue.dequeue();
+            expect(value).to.have.property('foo', 'bar');
+            expect(queue.peek()).to.have.property('bar', 'baz');
+            expect(queue.size()).to.equal(1);
+        });
+
+        it('should allow to clear the queue', function () {
+            var queue = store.getQueue('clientId6');
+            queue.enqueue({foo: 'bar'});
+            queue.enqueue({bar: 'baz'});
+            queue.flush();
+            expect(queue.peek()).to.be.undefined;
+            expect(queue.size()).to.equal(0);
+        });
+
+    });
+});

--- a/test/mocks/promises.js
+++ b/test/mocks/promises.js
@@ -1,0 +1,97 @@
+var nock = require('nock');
+
+nock('https://api.sandbox.paypal.com')
+  .post('/v1/oauth2/token', "grant_type=client_credentials")
+  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015Jik4tFmTbfRYQdy.rsF.VpEHB.prkpuS8R4EUgWfIHc","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":10}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=2694',
+  'paypal-debug-id': '4c4c6a50334b8',
+  server_info: 'identitysecuretokenserv:v1.oauth2.token&CalThreadId=769&TopLevelTxnStartTime=14a4e864b2b&Host=slcsbidensectoken501.slc.paypal.com&pid=3787',
+  date: 'Mon, 15 Dec 2014 15:17:11 GMT',
+  'content-type': 'application/json',
+  'content-length': '474' });
+
+nock('https://api.sandbox.paypal.com')
+  .post('/v1/payments/payouts/?sync_mode=false', {"sender_batch_header":{"sender_batch_id":"t1000","email_subject":"You have a payment"},"items":[{"recipient_type":"EMAIL","amount":{"value":0.99,"currency":"USD"},"receiver":"shirt-supplier-one@mail.com","note":"Thank you.","sender_item_id":"item_1"},{"recipient_type":"EMAIL","amount":{"value":0.9,"currency":"USD"},"receiver":"shirt-supplier-two@mail.com","note":"Thank you.","sender_item_id":"item_2"},{"recipient_type":"EMAIL","amount":{"value":0.15,"currency":"USD"},"receiver":"shirt-supplier-three@mail.com","note":"Thank you.","sender_item_id":"item_3"}]})
+  .reply(201, {"batch_header":{"payout_batch_id":"AJHKPW9KYBTWA","batch_status":"PENDING","sender_batch_header":{"email_subject":"You have a payment","sender_batch_id":"t1000"}},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/AJHKPW9KYBTWA","rel":"self","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=1216',
+  'paypal-debug-id': '47c84eee3c7f0',
+  'content-language': '*',
+  date: 'Mon, 15 Dec 2014 15:17:14 GMT',
+  'content-type': 'application/json',
+  'content-length': '278' });
+
+nock('https://api.sandbox.paypal.com')
+  .post('/v1/oauth2/token', "grant_type=client_credentials")
+  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015.ryo3JGimSC5n-AJBlIsivcVMnbba9NMH4fkAWBhgYs","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":28800}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=1048',
+  'paypal-debug-id': '90721dc2e051d',
+  server_info: 'identitysecuretokenserv:v1.oauth2.token&CalThreadId=73179&TopLevelTxnStartTime=14a5168375e&Host=slcsbidensectoken501.slc.paypal.com&pid=3787',
+  date: 'Tue, 16 Dec 2014 04:43:12 GMT',
+  'content-type': 'application/json',
+  'content-length': '474' });
+
+nock('https://api.sandbox.paypal.com')
+  .get('/v1/payments/payouts-item/VXURV6Y48P898')
+  .reply(200, {"payout_item_id":"VXURV6Y48P898","transaction_id":"5FU55828X3939910A","transaction_status":"UNCLAIMED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"7LHNN5KX7WVDC","sender_batch_id":"t400","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2014-40-16T10:40:53Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/VXURV6Y48P898","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/7LHNN5KX7WVDC","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=1213',
+  'paypal-debug-id': 'a1aa941bd8ed1',
+  'content-language': '*',
+  date: 'Wed, 17 Dec 2014 15:07:48 GMT',
+  'content-type': 'application/json',
+  'content-length': '730' });
+
+nock('https://api.sandbox.paypal.com')
+  .get('/v1/payments/payouts-item/5UD3FSLKEZ63C')
+  .reply(200, {"payout_item_id":"5UD3FSLKEZ63C","transaction_id":"5KT85791B7724820A","transaction_status":"RETURNED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"W46J7D4CQQTMY","sender_batch_id":"payout94","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2015-01-29T16:22:19Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered","information_link":"https://developer.paypal.com/webapps/developer/docs/api/#RECEIVER_UNREGISTERED"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/5UD3FSLKEZ63C","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/W46J7D4CQQTMY","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=415703',
+  'paypal-debug-id': '8e2061f56ed13',
+  'content-language': '*',
+  date: 'Thu, 29 Jan 2015 16:22:22 GMT',
+  'content-type': 'application/json',
+  'content-length': '833' });
+
+nock('https://api.sandbox.paypal.com')
+  .post('/v1/oauth2/token', "grant_type=client_credentials")
+  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015B4Rf1PvrSkSSgMpkfyvXJ-snbBHZEXudS9-8a6mn02A","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":28800}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=374233',
+  'paypal-debug-id': '3469156b10656',
+  server_info: 'identitysecuretokenserv:v1.oauth2.token&CalThreadId=388858&TopLevelTxnStartTime=14b3687f900&Host=slcsbidensectoken501.slc.paypal.com&pid=8642',
+  date: 'Thu, 29 Jan 2015 16:30:56 GMT',
+  'content-type': 'application/json',
+  'content-length': '474' });
+
+nock('https://api.sandbox.paypal.com')
+  .get('/v1/payments/payouts-item/5UD3FSLKEZ63')
+  .reply(200, {"payout_item_id":"5UD3FSLKEZ63C", "transaction_id":"5KT85791B7724820A","transaction_status":"RETURNED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"W46J7D4CQQTMY","sender_batch_id":"payout94","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2015-01-29T16:22:19Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered","information_link":"https://developer.paypal.com/webapps/developer/docs/api/#RECEIVER_UNREGISTERED"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/5UD3FSLKEZ63C","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/W46J7D4CQQTMY","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=415789',
+  'paypal-debug-id': '11f89e1310fa4',
+  'content-language': '*',
+  date: 'Thu, 29 Jan 2015 16:30:56 GMT',
+  connection: 'close, close',
+  'content-type': 'application/json',
+  'content-length': '183' });
+
+nock('https://api.sandbox.paypal.com')
+  .post('/v1/oauth2/token', "grant_type=client_credentials")
+  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015XK-QysP6bkUW0xMRhVPOZ054u.o1IKW444WrMi5WMjw","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":28800}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=371029',
+  'paypal-debug-id': '9644a9b91e08b',
+  server_info: 'identitysecuretokenserv:v1.oauth2.token&CalThreadId=132&TopLevelTxnStartTime=14b369718ae&Host=slcsbidensectoken501.slc.paypal.com&pid=8642',
+  date: 'Thu, 29 Jan 2015 16:47:27 GMT',
+  'content-type': 'application/json',
+  'content-length': '474' });
+
+nock('https://api.sandbox.paypal.com')
+  .get('/v1/payments/payouts-item/UK6HNZEQX8M8S')
+  .reply(401);
+
+nock('https://api.sandbox.paypal.com')
+  .get('/v1/payments/payouts-item/UK6HNZEQX8M8S')
+  .reply(200, {"payout_item_id":"UK6HNZEQX8M8S", "transaction_id":"5KT85791B7724820A","transaction_status":"RETURNED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"W46J7D4CQQTMY","sender_batch_id":"payout94","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2015-01-29T16:22:19Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered","information_link":"https://developer.paypal.com/webapps/developer/docs/api/#RECEIVER_UNREGISTERED"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/5UD3FSLKEZ63C","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/W46J7D4CQQTMY","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=424690',
+  'paypal-debug-id': '26c87e8102326',
+  'content-language': '*',
+  date: 'Thu, 29 Jan 2015 16:47:27 GMT',
+  connection: 'close, close',
+  'content-type': 'application/json',
+  'content-length': '193' });

--- a/test/mocks/promises.js
+++ b/test/mocks/promises.js
@@ -2,7 +2,7 @@ var nock = require('nock');
 
 nock('https://api.sandbox.paypal.com')
   .post('/v1/oauth2/token', "grant_type=client_credentials")
-  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015Jik4tFmTbfRYQdy.rsF.VpEHB.prkpuS8R4EUgWfIHc","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":10}, { server: 'Apache-Coyote/1.1',
+  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015Jik4tFmTbfRYQdy.rsF.VpEHB.prkpuS8R4EUgWfIHc","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":1}, { server: 'Apache-Coyote/1.1',
   proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=2694',
   'paypal-debug-id': '4c4c6a50334b8',
   server_info: 'identitysecuretokenserv:v1.oauth2.token&CalThreadId=769&TopLevelTxnStartTime=14a4e864b2b&Host=slcsbidensectoken501.slc.paypal.com&pid=3787',
@@ -12,6 +12,7 @@ nock('https://api.sandbox.paypal.com')
 
 nock('https://api.sandbox.paypal.com')
   .post('/v1/payments/payouts/?sync_mode=false', {"sender_batch_header":{"sender_batch_id":"t1000","email_subject":"You have a payment"},"items":[{"recipient_type":"EMAIL","amount":{"value":0.99,"currency":"USD"},"receiver":"shirt-supplier-one@mail.com","note":"Thank you.","sender_item_id":"item_1"},{"recipient_type":"EMAIL","amount":{"value":0.9,"currency":"USD"},"receiver":"shirt-supplier-two@mail.com","note":"Thank you.","sender_item_id":"item_2"},{"recipient_type":"EMAIL","amount":{"value":0.15,"currency":"USD"},"receiver":"shirt-supplier-three@mail.com","note":"Thank you.","sender_item_id":"item_3"}]})
+  .delay(1100)
   .reply(201, {"batch_header":{"payout_batch_id":"AJHKPW9KYBTWA","batch_status":"PENDING","sender_batch_header":{"email_subject":"You have a payment","sender_batch_id":"t1000"}},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/AJHKPW9KYBTWA","rel":"self","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
   proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=1216',
   'paypal-debug-id': '47c84eee3c7f0',
@@ -51,6 +52,17 @@ nock('https://api.sandbox.paypal.com')
   'content-length': '833' });
 
 nock('https://api.sandbox.paypal.com')
+  .get('/v1/payments/payouts-item/UK6HNZEQX8M8S')
+  .reply(200, {"payout_item_id":"UK6HNZEQX8M8S", "transaction_id":"5KT85791B7724820A","transaction_status":"RETURNED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"W46J7D4CQQTMY","sender_batch_id":"payout94","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2015-01-29T16:22:19Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered","information_link":"https://developer.paypal.com/webapps/developer/docs/api/#RECEIVER_UNREGISTERED"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/5UD3FSLKEZ63C","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/W46J7D4CQQTMY","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=424690',
+  'paypal-debug-id': '26c87e8102326',
+  'content-language': '*',
+  date: 'Thu, 29 Jan 2015 16:47:27 GMT',
+  connection: 'close, close',
+  'content-type': 'application/json',
+  'content-length': '193' });
+
+nock('https://api.sandbox.paypal.com')
   .post('/v1/oauth2/token', "grant_type=client_credentials")
   .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015B4Rf1PvrSkSSgMpkfyvXJ-snbBHZEXudS9-8a6mn02A","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":28800}, { server: 'Apache-Coyote/1.1',
   proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=374233',
@@ -61,37 +73,110 @@ nock('https://api.sandbox.paypal.com')
   'content-length': '474' });
 
 nock('https://api.sandbox.paypal.com')
-  .get('/v1/payments/payouts-item/5UD3FSLKEZ63')
-  .reply(200, {"payout_item_id":"5UD3FSLKEZ63C", "transaction_id":"5KT85791B7724820A","transaction_status":"RETURNED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"W46J7D4CQQTMY","sender_batch_id":"payout94","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2015-01-29T16:22:19Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered","information_link":"https://developer.paypal.com/webapps/developer/docs/api/#RECEIVER_UNREGISTERED"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/5UD3FSLKEZ63C","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/W46J7D4CQQTMY","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
-  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=415789',
-  'paypal-debug-id': '11f89e1310fa4',
-  'content-language': '*',
-  date: 'Thu, 29 Jan 2015 16:30:56 GMT',
-  connection: 'close, close',
-  'content-type': 'application/json',
-  'content-length': '183' });
+  .post('/v1/payments/payouts/?sync_mode=false', {"sender_batch_header":{"sender_batch_id":"t1000","email_subject":"You have a payment"},"items":[{"recipient_type":"EMAIL","amount":{"value":0.99,"currency":"USD"},"receiver":"shirt-supplier-one@mail.com","note":"Thank you.","sender_item_id":"item_1"},{"recipient_type":"EMAIL","amount":{"value":0.9,"currency":"USD"},"receiver":"shirt-supplier-two@mail.com","note":"Thank you.","sender_item_id":"item_2"},{"recipient_type":"EMAIL","amount":{"value":0.15,"currency":"USD"},"receiver":"shirt-supplier-three@mail.com","note":"Thank you.","sender_item_id":"item_3"}]})
+  .reply(401, "", { date: 'Tue, 11 Aug 2015 16:33:54 GMT',
+  server: 'Apache',
+  'paypal-debug-id': 'dfaf12d0c5dff',
+  'www-authenticate': 'Bearer error_description="Invalid Access Token",correlation_id="dfaf12d0c5dff",error="invalid_token",information_link="https://developer.paypal.com/docs/api/#errors",realm="UserInfoService"',
+  'set-cookie':
+  [ 'Apache=10.72.128.11.1439310834659319; path=/; expires=Thu, 03-Aug-45 16:33:54 GMT',
+    'X-PP-SILOVER=name%3DSANDBOX3.API.1%26silo_version%3D880%26app%3Didentityspartaweb_api%26TIME%3D4062431829; domain=.paypal.com; path=/; Secure; HttpOnly',
+    'X-PP-SILOVER=; Expires=Thu, 01 Jan 1970 00:00:01 GMT' ],
+  vary: 'Accept-Encoding',
+  connection: 'close',
+  'content-length': '0',
+  'content-type': 'text/html; charset=ISO-8859-1' });
+
+nock('https://api.sandbox.paypal.com')
+  .get('/v1/payments/payouts-item/VXURV6Y48P898')
+  .reply(401, "", { date: 'Tue, 11 Aug 2015 16:33:54 GMT',
+  server: 'Apache',
+  'paypal-debug-id': 'dfaf12d0c5dff',
+  'www-authenticate': 'Bearer error_description="Invalid Access Token",correlation_id="dfaf12d0c5dff",error="invalid_token",information_link="https://developer.paypal.com/docs/api/#errors",realm="UserInfoService"',
+  'set-cookie':
+    [ 'Apache=10.72.128.11.1439310834659319; path=/; expires=Thu, 03-Aug-45 16:33:54 GMT',
+      'X-PP-SILOVER=name%3DSANDBOX3.API.1%26silo_version%3D880%26app%3Didentityspartaweb_api%26TIME%3D4062431829; domain=.paypal.com; path=/; Secure; HttpOnly',
+      'X-PP-SILOVER=; Expires=Thu, 01 Jan 1970 00:00:01 GMT' ],
+  vary: 'Accept-Encoding',
+  connection: 'close',
+  'content-length': '0',
+  'content-type': 'text/html; charset=ISO-8859-1' });
 
 nock('https://api.sandbox.paypal.com')
   .post('/v1/oauth2/token', "grant_type=client_credentials")
-  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015XK-QysP6bkUW0xMRhVPOZ054u.o1IKW444WrMi5WMjw","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":28800}, { server: 'Apache-Coyote/1.1',
-  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=371029',
-  'paypal-debug-id': '9644a9b91e08b',
-  server_info: 'identitysecuretokenserv:v1.oauth2.token&CalThreadId=132&TopLevelTxnStartTime=14b369718ae&Host=slcsbidensectoken501.slc.paypal.com&pid=8642',
-  date: 'Thu, 29 Jan 2015 16:47:27 GMT',
+  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015Jik4tFmTbfRYQdy.rsF.VpEHB.prkpuS8R4EUgWfIHc","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":10}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=2694',
+  'paypal-debug-id': '4c4c6a50334b8',
+  server_info: 'identitysecuretokenserv:v1.oauth2.token&CalThreadId=769&TopLevelTxnStartTime=14a4e864b2b&Host=slcsbidensectoken501.slc.paypal.com&pid=3787',
+  date: 'Mon, 15 Dec 2014 15:17:11 GMT',
   'content-type': 'application/json',
   'content-length': '474' });
 
 nock('https://api.sandbox.paypal.com')
-  .get('/v1/payments/payouts-item/UK6HNZEQX8M8S')
-  .reply(401);
+  .post('/v1/payments/payouts/?sync_mode=false', {"sender_batch_header":{"sender_batch_id":"t1000","email_subject":"You have a payment"},"items":[{"recipient_type":"EMAIL","amount":{"value":0.99,"currency":"USD"},"receiver":"shirt-supplier-one@mail.com","note":"Thank you.","sender_item_id":"item_1"},{"recipient_type":"EMAIL","amount":{"value":0.9,"currency":"USD"},"receiver":"shirt-supplier-two@mail.com","note":"Thank you.","sender_item_id":"item_2"},{"recipient_type":"EMAIL","amount":{"value":0.15,"currency":"USD"},"receiver":"shirt-supplier-three@mail.com","note":"Thank you.","sender_item_id":"item_3"}]})
+  .reply(201, {"batch_header":{"payout_batch_id":"AJHKPW9KYBTWA","batch_status":"PENDING","sender_batch_header":{"email_subject":"You have a payment","sender_batch_id":"t1000"}},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/AJHKPW9KYBTWA","rel":"self","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=1216',
+  'paypal-debug-id': '47c84eee3c7f0',
+  'content-language': '*',
+  date: 'Mon, 15 Dec 2014 15:17:14 GMT',
+  'content-type': 'application/json',
+  'content-length': '278' });
 
 nock('https://api.sandbox.paypal.com')
-  .get('/v1/payments/payouts-item/UK6HNZEQX8M8S')
-  .reply(200, {"payout_item_id":"UK6HNZEQX8M8S", "transaction_id":"5KT85791B7724820A","transaction_status":"RETURNED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"W46J7D4CQQTMY","sender_batch_id":"payout94","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2015-01-29T16:22:19Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered","information_link":"https://developer.paypal.com/webapps/developer/docs/api/#RECEIVER_UNREGISTERED"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/5UD3FSLKEZ63C","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/W46J7D4CQQTMY","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
-  proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=424690',
-  'paypal-debug-id': '26c87e8102326',
+  .get('/v1/payments/payouts-item/VXURV6Y48P898')
+  .reply(200, {"payout_item_id":"VXURV6Y48P898","transaction_id":"5FU55828X3939910A","transaction_status":"UNCLAIMED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"7LHNN5KX7WVDC","sender_batch_id":"t400","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2014-40-16T10:40:53Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/VXURV6Y48P898","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/7LHNN5KX7WVDC","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=1213',
+  'paypal-debug-id': 'a1aa941bd8ed1',
   'content-language': '*',
-  date: 'Thu, 29 Jan 2015 16:47:27 GMT',
-  connection: 'close, close',
+  date: 'Wed, 17 Dec 2014 15:07:48 GMT',
   'content-type': 'application/json',
-  'content-length': '193' });
+  'content-length': '730' });
+
+nock('https://api.sandbox.paypal.com')
+  .post('/v1/payments/payouts/?sync_mode=false', {"sender_batch_header":{"sender_batch_id":"t1000","email_subject":"You have a payment"},"items":[{"recipient_type":"EMAIL","amount":{"value":0.99,"currency":"USD"},"receiver":"shirt-supplier-one@mail.com","note":"Thank you.","sender_item_id":"item_1"},{"recipient_type":"EMAIL","amount":{"value":0.9,"currency":"USD"},"receiver":"shirt-supplier-two@mail.com","note":"Thank you.","sender_item_id":"item_2"},{"recipient_type":"EMAIL","amount":{"value":0.15,"currency":"USD"},"receiver":"shirt-supplier-three@mail.com","note":"Thank you.","sender_item_id":"item_3"}]})
+  .reply(401, "", { date: 'Tue, 11 Aug 2015 16:33:54 GMT',
+  server: 'Apache',
+  'paypal-debug-id': 'dfaf12d0c5dff',
+  'www-authenticate': 'Bearer error_description="Invalid Access Token",correlation_id="dfaf12d0c5dff",error="invalid_token",information_link="https://developer.paypal.com/docs/api/#errors",realm="UserInfoService"',
+  'set-cookie':
+    [ 'Apache=10.72.128.11.1439310834659319; path=/; expires=Thu, 03-Aug-45 16:33:54 GMT',
+      'X-PP-SILOVER=name%3DSANDBOX3.API.1%26silo_version%3D880%26app%3Didentityspartaweb_api%26TIME%3D4062431829; domain=.paypal.com; path=/; Secure; HttpOnly',
+      'X-PP-SILOVER=; Expires=Thu, 01 Jan 1970 00:00:01 GMT' ],
+  vary: 'Accept-Encoding',
+  connection: 'close',
+  'content-length': '0',
+  'content-type': 'text/html; charset=ISO-8859-1' });
+
+nock('https://api.sandbox.paypal.com')
+  .get('/v1/payments/payouts-item/VXURV6Y48P898')
+  .delay(500)
+  .reply(200, {"payout_item_id":"VXURV6Y48P898","transaction_id":"5FU55828X3939910A","transaction_status":"UNCLAIMED","payout_item_fee":{"currency":"USD","value":"0.0"},"payout_batch_id":"7LHNN5KX7WVDC","sender_batch_id":"t400","payout_item":{"amount":{"currency":"USD","value":"0.15"},"note":"Thank you.","receiver":"shirt-supplier-three@mail.com","recipient_type":"EMAIL","sender_item_id":"item_3"},"time_processed":"2014-40-16T10:40:53Z","errors":{"name":"RECEIVER_UNREGISTERED","message":"Receiver is unregistered"},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts-item/VXURV6Y48P898","rel":"self","method":"GET"},{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/7LHNN5KX7WVDC","rel":"batch","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=1213',
+  'paypal-debug-id': 'a1aa941bd8ed1',
+  'content-language': '*',
+  date: 'Wed, 17 Dec 2014 15:07:48 GMT',
+  'content-type': 'application/json',
+  'content-length': '730' });
+
+nock('https://api.sandbox.paypal.com')
+  .post('/v1/oauth2/token', "grant_type=client_credentials")
+  .delay(110)
+  .reply(200, {"scope":"https://uri.paypal.com/services/subscriptions https://api.paypal.com/v1/payments/.* email https://api.paypal.com/v1/vault/credit-card https://uri.paypal.com/services/applications/webhooks openid https://uri.paypal.com/services/invoicing https://uri.paypal.com/payments/payouts https://api.paypal.com/v1/vault/credit-card/.*","access_token":"A015Jik4tFmTbfRYQdy.rsF.VpEHB.prkpuS8R4EUgWfIHc","token_type":"Bearer","app_id":"APP-80W284485P519543T","expires_in":10}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3001.slc.paypal.com;threadId=2694',
+  'paypal-debug-id': '4c4c6a50334b8',
+  server_info: 'identitysecuretokenserv:v1.oauth2.token&CalThreadId=769&TopLevelTxnStartTime=14a4e864b2b&Host=slcsbidensectoken501.slc.paypal.com&pid=3787',
+  date: 'Mon, 15 Dec 2014 15:17:11 GMT',
+  'content-type': 'application/json',
+  'content-length': '474' });
+
+nock('https://api.sandbox.paypal.com')
+  .post('/v1/payments/payouts/?sync_mode=false', {"sender_batch_header":{"sender_batch_id":"t1000","email_subject":"You have a payment"},"items":[{"recipient_type":"EMAIL","amount":{"value":0.99,"currency":"USD"},"receiver":"shirt-supplier-one@mail.com","note":"Thank you.","sender_item_id":"item_1"},{"recipient_type":"EMAIL","amount":{"value":0.9,"currency":"USD"},"receiver":"shirt-supplier-two@mail.com","note":"Thank you.","sender_item_id":"item_2"},{"recipient_type":"EMAIL","amount":{"value":0.15,"currency":"USD"},"receiver":"shirt-supplier-three@mail.com","note":"Thank you.","sender_item_id":"item_3"}]})
+  .reply(201, {"batch_header":{"payout_batch_id":"AJHKPW9KYBTWA","batch_status":"PENDING","sender_batch_header":{"email_subject":"You have a payment","sender_batch_id":"t1000"}},"links":[{"href":"https://api.sandbox.paypal.com/v1/payments/payouts/AJHKPW9KYBTWA","rel":"self","method":"GET"}]}, { server: 'Apache-Coyote/1.1',
+  proxy_server_info: 'host=slcsbplatformapiserv3002.slc.paypal.com;threadId=1216',
+  'paypal-debug-id': '47c84eee3c7f0',
+  'content-language': '*',
+  date: 'Mon, 15 Dec 2014 15:17:14 GMT',
+  'content-type': 'application/json',
+  'content-length': '278' });
+
+

--- a/test/promises.js
+++ b/test/promises.js
@@ -59,16 +59,15 @@ describe('Promises', function () {
         require('./mocks/promises');
     }
 
-    it('uses promise style request', function (done) {
+    it('uses promise style request', function () {
         return paypal.payout.create(create_batch_payout_json).then(function (payout) {
             expect(payout.batch_header.payout_batch_id).to.not.equal(null);
             expect(payout.batch_header.sender_batch_header.sender_batch_id).to.equal(sender_batch_id);
             expect(payout.links).to.not.be.empty;
-            done();
         });
     });
 
-    it('joins requests with different clientIds and refreshing tokens without failing', function (done) {
+    it('joins requests with different clientIds and refreshing tokens without failing', function () {
         return Promise.all([
             paypal.payoutItem.get(payout_item_id1),
             paypal.payoutItem.get(payout_item_id2, {
@@ -78,7 +77,6 @@ describe('Promises', function () {
             paypal.payoutItem.get(payout_item_id3)
         ]).then(function (payoutItems) {
             expect(payoutItems).not.to.be.empty;
-            done();
         });
     });
 

--- a/test/promises.js
+++ b/test/promises.js
@@ -7,7 +7,13 @@ var chai = require('chai'),
     Promise = global.Promise || require('es6-promise');
 
 var paypal = require('../');
-require('./configure');
+
+// Changing the client id is required so tokens from other tests are not reused
+paypal.configure({
+    'mode': 'sandbox',
+    'client_id': 'clientId1',
+    'client_secret': 'clientSecret'
+});
 
 
 describe('Promises', function () {
@@ -15,6 +21,7 @@ describe('Promises', function () {
     var payout_item_id2 = '5UD3FSLKEZ63C';
     var payout_item_id3 = 'UK6HNZEQX8M8S';
     var sender_batch_id = "t1000";
+
 
     var create_batch_payout_json = {
         "sender_batch_header": {
@@ -59,24 +66,51 @@ describe('Promises', function () {
         require('./mocks/promises');
     }
 
-    it('uses promise style request', function () {
-        return paypal.payout.create(create_batch_payout_json).then(function (payout) {
-            expect(payout.batch_header.payout_batch_id).to.not.equal(null);
-            expect(payout.batch_header.sender_batch_header.sender_batch_id).to.equal(sender_batch_id);
-            expect(payout.links).to.not.be.empty;
+    it('joins requests with different clientIds and refreshing tokens without failing', function () {
+        return paypal.payout.create(create_batch_payout_json) // no token for client, 1s expiration, 1.1s request delay
+            .then(function (payout) {
+                expect(payout).to.have.property('batch_header');
+                return Promise.all([
+                    paypal.payoutItem.get(payout_item_id1), // token expired
+                    paypal.payoutItem.get(payout_item_id2, { // different client, no token
+                        'client_id': 'clientId2',
+                        'client_secret': 'clientSecret2'
+                    }),
+                    paypal.payoutItem.get(payout_item_id3) // refreshing
+                ]);
+            })
+            .then(function (payoutItems) {
+                expect(payoutItems).to.have.length(3);
+                payoutItems.forEach(function (item) {
+                    expect(item).to.have.property('payout_item_id');
+                });
+            });
+    });
+
+    it('should refresh the token when concurrent calls receive a 401 response', function () {
+        return Promise.all([
+            paypal.payout.create(create_batch_payout_json), // valid token, receive 401, not refreshing
+            paypal.payoutItem.get(payout_item_id1) // valid token, receive 401, refreshing
+        ]).then(function (response) {
+            expect(response).to.have.length(2);
+            expect(response[0]).to.have.property('batch_header');
+            expect(response[1]).to.have.property('payout_item_id');
         });
     });
 
-    it('joins requests with different clientIds and refreshing tokens without failing', function () {
+    it('should queue the call when a response receives a 401 response', function () {
+        var delayedPromise = new Promise(function (resolve, reject) {
+            setTimeout(function () {
+                paypal.payoutItem.get(payout_item_id1).then(resolve, reject);
+            }, 100);
+        });
         return Promise.all([
-            paypal.payoutItem.get(payout_item_id1),
-            paypal.payoutItem.get(payout_item_id2, {
-                'client_id': 'client_id',
-                'client_secret': 'client_secret'
-            }),
-            paypal.payoutItem.get(payout_item_id3)
-        ]).then(function (payoutItems) {
-            expect(payoutItems).not.to.be.empty;
+            paypal.payout.create(create_batch_payout_json), // valid token, receive 401, not refreshing
+            delayedPromise // refreshing
+        ]).then(function (response) {
+            expect(response).to.have.length(2);
+            expect(response[0]).to.have.property('batch_header');
+            expect(response[1]).to.have.property('payout_item_id');
         });
     });
 

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,0 +1,85 @@
+/* Copyright 2015-2016 PayPal, Inc. */
+"use strict";
+
+var chai = require('chai'),
+    expect = chai.expect,
+    should = chai.should(),
+    Promise = global.Promise || require('es6-promise');
+
+var paypal = require('../');
+require('./configure');
+
+
+describe('Promises', function () {
+    var payout_item_id1 = 'VXURV6Y48P898';
+    var payout_item_id2 = '5UD3FSLKEZ63C';
+    var payout_item_id3 = 'UK6HNZEQX8M8S';
+    var sender_batch_id = "t1000";
+
+    var create_batch_payout_json = {
+        "sender_batch_header": {
+            "sender_batch_id": sender_batch_id,
+            "email_subject": "You have a payment"
+        },
+        "items": [
+            {
+                "recipient_type": "EMAIL",
+                "amount": {
+                    "value": 0.99,
+                    "currency": "USD"
+                },
+                "receiver": "shirt-supplier-one@mail.com",
+                "note": "Thank you.",
+                "sender_item_id": "item_1"
+            },
+            {
+                "recipient_type": "EMAIL",
+                "amount": {
+                    "value": 0.90,
+                    "currency": "USD"
+                },
+                "receiver": "shirt-supplier-two@mail.com",
+                "note": "Thank you.",
+                "sender_item_id": "item_2"
+            },
+            {
+                "recipient_type": "EMAIL",
+                "amount": {
+                    "value": 0.15,
+                    "currency": "USD"
+                },
+                "receiver": "shirt-supplier-three@mail.com",
+                "note": "Thank you.",
+                "sender_item_id": "item_3"
+            }
+        ]
+    };
+
+    if (process.env.NOCK_OFF !== 'true') {
+        require('./mocks/promises');
+    }
+
+    it('uses promise style request', function (done) {
+        return paypal.payout.create(create_batch_payout_json).then(function (payout) {
+            expect(payout.batch_header.payout_batch_id).to.not.equal(null);
+            expect(payout.batch_header.sender_batch_header.sender_batch_id).to.equal(sender_batch_id);
+            expect(payout.links).to.not.be.empty;
+            done();
+        });
+    });
+
+    it('joins requests with different clientIds and refreshing tokens without failing', function (done) {
+        return Promise.all([
+            paypal.payoutItem.get(payout_item_id1),
+            paypal.payoutItem.get(payout_item_id2, {
+                'client_id': 'client_id',
+                'client_secret': 'client_secret'
+            }),
+            paypal.payoutItem.get(payout_item_id3)
+        ]).then(function (payoutItems) {
+            expect(payoutItems).not.to.be.empty;
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
This PR solves issue #234 and adds support for promises without removing callbacks and preserving backwards compatibility with node engine version. It's also capable of dealing with concurrent request and only refresh tokens once for every client when one of the concurrent calls fails.

It introduces two dependencies [pify](https://github.com/sindresorhus/pify) and [es6-promise](https://github.com/stefanpenner/es6-promise). The last is required for promise support in Node <0.12. Maintainers of this module may choose another promise library if desired.

The current callback style have a bug when used in conjunction with libraries methods like [async.parallel](https://caolan.github.io/async/docs.html#parallel) which tries to refresh the token more than once if any of the calls fails. This PR also deals solves this issue.

I added some tests (by copy-paste) to check everything work as expected but maintainers should add more to be able to test more SDK functions and record real calls with nock but be aware that some of my tests have a token expiration of 1s (to test expired tokens) and delays to test concurrency handling.