### PR TITLE
change debug output from NODE_ENV to PAYPAL_DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ NOCK_OFF=true mocha -t 60000
 
 
 ## Debugging
-   * As of version 1.6.2, full request/response are logged for non production environments with NODE_ENV=development set
+   * As of version 1.6.2, full request/response are logged for non production environments with PAYPAL_DEBUG set
 
-     You can set the environment variable on the command line by running `NODE_ENV=development node <path of script>` or by executing `export NODE_ENV=development` and then running your Node.js script. Please see your command terminal/shell's manual pages for specific information.
+     You can set the environment variable on the command line by running `PAYPAL_DEBUG=1 node <path of script>` or by executing `export PAYPAL_DEBUG=1` and then running your Node.js script. Please see your command terminal/shell's manual pages for specific information.
 
-   * It is recommended to provide Paypal-Debug-Id if requesting PayPal Merchant Technical Services for support. You can get access to the debug id by setting environment variable NODE_ENV=development.
-   * The error object returned for any bad request has error.response populated with [details](https://developer.paypal.com/docs/api/payments/#errors). NODE_ENV=development setting also gives you access to stringfied response in error messages.
+   * It is recommended to provide Paypal-Debug-Id if requesting PayPal Merchant Technical Services for support. You can get access to the debug id by setting environment variable PAYPAL_DEBUG=1.
+   * The error object returned for any bad request has error.response populated with [details](https://developer.paypal.com/docs/api/payments/#errors). PAYPAL_DEBUG=1 setting also gives you access to stringfied response in error messages.
 
 ## Reference
    [REST API Reference] (https://developer.paypal.com/webapps/developer/docs/api/)

--- a/lib/client.js
+++ b/lib/client.js
@@ -61,7 +61,7 @@ var invoke = exports.invoke = function invoke(http_method, path, data, http_opti
     }
 
     // Enable full request response logging in development/non-production environment only
-    if (configuration.default_options.mode !== 'live' && process.env.NODE_ENV === 'development') {
+    if (configuration.default_options.mode !== 'live' && process.env.PAYPAL_DEBUG) {
         console.dir(JSON.stringify(http_options.headers));
         console.dir(request_data);
     }
@@ -92,9 +92,9 @@ var invoke = exports.invoke = function invoke(http_method, path, data, http_opti
             var err = null;
 
             try {
-                //TURN NODE_ENV to development to get access to paypal-debug-id
+                //export PAYPAL_DEBUG to development to get access to paypal-debug-id
                 //for questions to merchant technical services.
-                if (res.headers['paypal-debug-id'] !== undefined && process.env.NODE_ENV === 'development') {
+                if (res.headers['paypal-debug-id'] !== undefined && process.env.PAYPAL_DEBUG) {
                     console.log('paypal-debug-id: ' + res.headers['paypal-debug-id']);
 
                     if (configuration.default_options.mode !== 'live') {
@@ -131,7 +131,7 @@ var invoke = exports.invoke = function invoke(http_method, path, data, http_opti
                 // response contains the full json description of the error
                 // that PayPal returns and information link
                 err.response = response;
-                if (process.env.NODE_ENV === 'development') {
+                if (process.env.PAYPAL_DEBUG) {
                     err.response_stringified = JSON.stringify(response);
                 }
                 err.httpStatusCode = res.statusCode;


### PR DESCRIPTION
NODE_ENV is used by a ton of other things in nodejs ecosystem.  Enabling a ton of debugging on that environment variable clutters up the logs for developers wanting to see other errors.  Switching to PAYPAL_DEBUG so that it is set specifically for the PayPal SDK