### PR TITLE
Add retry and idempotency

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -4,6 +4,7 @@
 var client = require('./client');
 var utils = require('./utils');
 var configuration = require('./configure');
+var uuid = require('uuid/v1');
 
 /**
  * token_persist client id to access token cache, used to reduce access token round trips
@@ -88,24 +89,6 @@ var generateToken = exports.generateToken = function generateToken(config, cb) {
     });
 };
 
-/* Update authorization header with new token obtained by calling
-generateToken */
-/**
- * Updates http Authorization header to newly created access token
- * @param  {Object}   http_options   Configuration parameters such as authorization code or refresh token
- * @param  {Function}   error_callback 
- * @param  {Function} callback       
- */
-function updateToken(http_options, error_callback, callback) {
-    generateToken(http_options, function (error, token) {
-        if (error) {
-            error_callback(error, token);
-        } else {
-            http_options.headers.Authorization = token;
-            callback();
-        }
-    });
-}
 
 /**
  * Makes a PayPal REST API call. Reuses valid access tokens to reduce
@@ -130,8 +113,27 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
     //Get host endpoint using mode
     http_options.host = http_options.host || utils.getDefaultApiEndpoint(http_options.mode);
 
+    var retries = http_options.retries || 0;
+    var retriableErrors = ['ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED', 'EHOSTUNREACH', 'EPIPE', 'EAI_AGAIN'];
+
     function retryInvoke() {
         client.invoke(http_method, path, data, http_options, cb);
+    }
+
+    function updateToken(http_options, error_callback, callback) {
+        generateToken(http_options, function (error, token) {
+            if (error) {
+                if ((error.httpStatusCode === 500 || retriableErrors.indexOf(error.code) !== -1) && retries > 0) {
+                    retries--;
+                    updateToken(http_options, error_callback, callback);
+                } else {
+                    error_callback(error, token);
+                }
+            } else {
+                http_options.headers.Authorization = token;
+                callback();
+            }
+        });
     }
 
     // correlation-id is deprecated in favor of client-metadata-id
@@ -142,6 +144,8 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
         http_options.headers['Paypal-Client-Metadata-Id'] = http_options.correlation_id;
     }
 
+    http_options.headers['PAYPAL-REQUEST-ID'] = uuid();
+
     // If client_id exists with an unexpired token and a refresh token is not provided, reuse cached token    
     if (http_options.client_id in token_persist && !utils.checkExpiredToken(token_persist[http_options.client_id]) && !http_options.refresh_token) {
         http_options.headers.Authorization = "Bearer " + token_persist[http_options.client_id].access_token;
@@ -151,7 +155,12 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
             if (error && error.httpStatusCode === 401 && http_options.client_id && http_options.headers.Authorization) {
                 http_options.headers.Authorization = null;
                 updateToken(http_options, cb, retryInvoke);
-            } else {
+            // TODO: What is the exact error.message for internal server errors?
+            } else if (error && ((error.httpStatusCode === 500 && error.message === 'Internal_Server_Error') || retriableErrors.indexOf(error.code) !== -1) && retries > 0) {
+                retries--;
+                retryInvoke();
+            }
+            else {
                 cb(error, response);
             }
         });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "main": "./index.js",
   "dependencies": {
     "buffer-crc32": "^0.2.3",
-    "semver": "^5.0.3"
+    "semver": "^5.0.3",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "blanket": "~1.1.5",
@@ -47,7 +48,7 @@
     }
   },
   "scripts": {
-    "test": "grunt"
+    "test": "NODE_ENV=test grunt"
   },
   "readmeFilename": "README.md"
 }

--- a/samples/configure.js
+++ b/samples/configure.js
@@ -6,5 +6,6 @@ paypal.configure({
     'client_secret': 'EO422dn3gQLgDbuwqTjzrFgFtaRLRR5BdHEESmha49TM',
     'headers' : {
 		'custom': 'header'
-    }
+    },
+    retries: 3
 });


### PR DESCRIPTION
Add retry logic and idempotency.

1.  Idempotency for all api calls
2.  Retry logic for all "retryable" http error codes
3.  Retry logic for 500 Internal Server Error

Need someone to tell me what the exact error message is for internal server error.  

https://github.com/trainerbill/PayPal-node-SDK/blob/RetryRedo/lib/api.js#L158-L159

I tested by adding this to my host file:
```
2.2.2.2         api.sandbox.paypal.com
```

but we need to figure out how to test the internal server error logic.
