### PR TITLE
don't overwrite user-provided `host` config

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -59,7 +59,7 @@ var generateToken = exports.generateToken = function generateToken(config, cb) {
 
     var http_options = {
         schema: config.schema || configuration.default_options.schema,
-        host: utils.getDefaultApiEndpoint(config.mode) || config.host || configuration.default_options.host,
+        host: config.host || utils.getDefaultApiEndpoint(config.mode) || configuration.default_options.host,
         port: config.port || configuration.default_options.port,
         headers: utils.merge({
             'Authorization': basicAuthString,
@@ -128,7 +128,7 @@ var executeHttp = exports.executeHttp = function executeHttp(http_method, path, 
     }
 
     //Get host endpoint using mode
-    http_options.host = utils.getDefaultApiEndpoint(http_options.mode) || http_options.host;
+    http_options.host = http_options.host || utils.getDefaultApiEndpoint(http_options.mode);
 
     function retryInvoke() {
         client.invoke(http_method, path, data, http_options, cb);


### PR DESCRIPTION
If we want to stub out a fake PayPal server at address `http://localhost:1234`, we would like to provide a `http://localhost:1234` as the `host` in our PayPal client. However in the current way of things, the `host` I provide is overwritten by `utils.getDefaultApiEndpoint(config.mode)`. This change should allow us to use the user provided `host` for testing purposes.