### PR TITLE
Fix for invalid chars in exported user agent header

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -2,7 +2,7 @@
 "use strict";
 
 var sdkVersion = exports.sdkVersion = require('../package').version;
-var userAgent = exports.userAgent = 'PayPalSDK/PayPal-node-SDK ' + sdkVersion + ' (node ' + process.version + '-' + process.arch + '-' + process.platform  + '; OpenSSL ' + process.versions.openssl + ')';
+var userAgent = exports.userAgent = encodeURIComponent('PayPalSDK/PayPal-node-SDK ' + sdkVersion + ' (node ' + process.version + '-' + process.arch + '-' + process.platform  + '; OpenSSL ' + process.versions.openssl + ')');
 
 var default_options = exports.default_options = {
     'mode': 'sandbox',


### PR DESCRIPTION
URI encoding of the user agent header.
When invalid characters that node didn't support were present the header would be malformed and the request would fail. 
