### PR TITLE
Add /Billing/Subscription - Paypal API deprecated Billing Agreements

### DIFF
--- a/lib/v1/billing/lib.js
+++ b/lib/v1/billing/lib.js
@@ -1,0 +1,6 @@
+"use strict";
+/* eslint-disable comma-dangle*/
+
+module.exports = {
+  subscriptions: require("./subscriptions/lib")
+};

--- a/lib/v1/billing/subscriptions/lib.js
+++ b/lib/v1/billing/subscriptions/lib.js
@@ -1,0 +1,14 @@
+"use strict";
+/* eslint-disable comma-dangle*/
+
+module.exports = {
+  SubscriptionActivateRequest: require("./subscriptionActivateRequest").SubscriptionActivateRequest,
+  SubscriptionCancelRequest: require("./subscriptionCancelRequest").SubscriptionCancelRequest,
+  SubscriptionCapturePayment: require("./subscriptionCapturePayment").SubscriptionCapturePayment,
+  SubscriptionCreateRequest: require("./subscriptionCreateRequest").SubscriptionCreateRequest,
+  SubscriptionGetRequest: require("./subscriptionGetRequest").SubscriptionGetRequest,
+  SubscriptionGetTransactions: require("./subscriptionGetTransactions").SubscriptionGetTransactions,
+  SubscriptionSuspendRequest: require("./subscriptionSuspendRequest").SubscriptionSuspendRequest,
+  SubscriptionUpdateQuantity: require("./subscriptionUpdateQuantity").SubscriptionUpdateQuantity,
+  SubscriptionUpdateRequest: require("./subscriptionUpdateRequest").SubscriptionUpdateRequest,
+};

--- a/lib/v1/billing/subscriptions/subscriptionActivateRequest.js
+++ b/lib/v1/billing/subscriptions/subscriptionActivateRequest.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const querystring = require("querystring"); // eslint-disable-line no-unused-vars
+/**
+ Re-activates a suspended billing agreement, by ID. In the JSON request body, include an `agreement_state_descriptor` object with with a note that describes the reason for the re-activation and the agreement amount and currency.
+ **/
+
+class SubscriptionActivateRequest {
+  constructor(subscription_id) {
+    this.path = "/v1/billing/subscriptions/{subscription_id}/activate?";
+    this.path = this.path.replace(
+      "{subscription_id}",
+      querystring.escape(subscription_id)
+    );
+    this.verb = "POST";
+    this.body = null;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+  }
+
+  requestBody(activateRequestReason) {
+    this.body = activateRequestReason;
+    return this;
+  }
+}
+
+module.exports = { SubscriptionActivateRequest: SubscriptionActivateRequest };

--- a/lib/v1/billing/subscriptions/subscriptionCancelRequest.js
+++ b/lib/v1/billing/subscriptions/subscriptionCancelRequest.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const querystring = require("querystring"); // eslint-disable-line no-unused-vars
+/**
+ Re-activates a suspended billing agreement, by ID. In the JSON request body, include an `agreement_state_descriptor` object with with a note that describes the reason for the re-activation and the agreement amount and currency.
+ **/
+
+class SubscriptionCancelRequest {
+  constructor(subscription_id) {
+    this.path = "/v1/billing/subscriptions/{subscription_id}/activate?";
+    this.path = this.path.replace(
+      "{subscription_id}",
+      querystring.escape(subscription_id)
+    );
+    this.verb = "POST";
+    this.body = null;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+  }
+
+  requestBody(cancelRequestReason) {
+    this.body = cancelRequestReason;
+    return this;
+  }
+}
+
+module.exports = { SubscriptionCancelRequest: SubscriptionCancelRequest };

--- a/lib/v1/billing/subscriptions/subscriptionCapturePayment.js
+++ b/lib/v1/billing/subscriptions/subscriptionCapturePayment.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const querystring = require("querystring"); // eslint-disable-line no-unused-vars
+/**
+ Re-activates a suspended billing agreement, by ID. In the JSON request body, include an `agreement_state_descriptor` object with with a note that describes the reason for the re-activation and the agreement amount and currency.
+ **/
+
+class SubscriptionCapturePayment {
+  constructor(subscription_id) {
+    this.path = "/v1/billing/subscriptions/{subscription_id}/capture?";
+    this.path = this.path.replace(
+      "{subscription_id}",
+      querystring.escape(subscription_id)
+    );
+    this.verb = "POST";
+    this.body = null;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+  }
+
+  requestBody(paymentCaptureRequest) {
+    this.body = paymentCaptureRequest;
+    return this;
+  }
+}
+
+module.exports = { SubscriptionCapturePayment: SubscriptionCapturePayment };

--- a/lib/v1/billing/subscriptions/subscriptionCreateRequest.js
+++ b/lib/v1/billing/subscriptions/subscriptionCreateRequest.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const querystring = require("querystring"); // eslint-disable-line no-unused-vars
+/**
+ Creates a billing agreement. In the JSON request body, include an `agreement` object with the name, description, start date, ID of the plan on which to base the agreement, and customer and shipping address information.
+ **/
+
+class SubscriptionCreateRequest {
+  constructor() {
+    this.path = "/v1/payments/billing/subscriptions/?";
+    this.verb = "POST";
+    this.body = null;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+  }
+
+  requestBody(subscription) {
+    this.body = subscription;
+    return this;
+  }
+}
+
+module.exports = { SubscriptionCreateRequest: SubscriptionCreateRequest };

--- a/lib/v1/billing/subscriptions/subscriptionGetRequest.js
+++ b/lib/v1/billing/subscriptions/subscriptionGetRequest.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const querystring = require("querystring"); // eslint-disable-line no-unused-vars
+/**
+ Shows details for a billing agreement, by ID.
+ **/
+
+class SubscriptionGetRequest {
+  constructor(subscription_id) {
+    this.path = "/v1/billing/subscriptions/{subscription_id}?";
+    this.path = this.path.replace(
+      "{subscription_id}",
+      querystring.escape(subscription_id)
+    );
+    this.verb = "GET";
+    this.body = null;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+  }
+}
+
+module.exports = { SubscriptionGetRequest: SubscriptionGetRequest };

--- a/lib/v1/billing/subscriptions/subscriptionSuspendRequest.js
+++ b/lib/v1/billing/subscriptions/subscriptionSuspendRequest.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const querystring = require("querystring"); // eslint-disable-line no-unused-vars
+/**
+ Re-activates a suspended billing agreement, by ID. In the JSON request body, include an `agreement_state_descriptor` object with with a note that describes the reason for the re-activation and the agreement amount and currency.
+ **/
+
+class SubscriptionSuspendRequest {
+  constructor(subscription_id) {
+    this.path = "/v1/billing/subscriptions/{subscription_id}/suspend?";
+    this.path = this.path.replace(
+      "{subscription_id}",
+      querystring.escape(subscription_id)
+    );
+    this.verb = "POST";
+    this.body = null;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+  }
+
+  requestBody(suspendReason) {
+    this.body = suspendReason;
+    return this;
+  }
+}
+
+module.exports = { SubscriptionSuspendRequest: SubscriptionSuspendRequest };

--- a/lib/v1/billing/subscriptions/subscriptionUpdateQuantity.js
+++ b/lib/v1/billing/subscriptions/subscriptionUpdateQuantity.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const querystring = require("querystring"); // eslint-disable-line no-unused-vars
+/**
+ Re-activates a suspended billing agreement, by ID. In the JSON request body, include an `agreement_state_descriptor` object with with a note that describes the reason for the re-activation and the agreement amount and currency.
+ **/
+
+class SubscriptionUpdateQuantity {
+  constructor(subscription_id) {
+    this.path = "/v1/billing/subscriptions/{subscription_id}/revise?";
+    this.path = this.path.replace(
+      "{subscription_id}",
+      querystring.escape(subscription_id)
+    );
+    this.verb = "POST";
+    this.body = null;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+  }
+
+  requestBody(quantityUpdate) {
+    this.body = quantityUpdate;
+    return this;
+  }
+}
+
+module.exports = { SubscriptionUpdateQuantity: SubscriptionUpdateQuantity };

--- a/lib/v1/billing/subscriptions/subscriptionUpdateRequest.js
+++ b/lib/v1/billing/subscriptions/subscriptionUpdateRequest.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const querystring = require("querystring"); // eslint-disable-line no-unused-vars
+/**
+ Re-activates a suspended billing agreement, by ID. In the JSON request body, include an `agreement_state_descriptor` object with with a note that describes the reason for the re-activation and the agreement amount and currency.
+ **/
+
+class SubscriptionUpdateRequest {
+  constructor(subscription_id) {
+    this.path = "/v1/billing/subscriptions/{subscription_id}?";
+    this.path = this.path.replace(
+      "{subscription_id}",
+      querystring.escape(subscription_id)
+    );
+    this.verb = "PATCH";
+    this.body = null;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+  }
+
+  requestBody(patchBody) {
+    this.body = patchBody;
+    return this;
+  }
+}
+
+module.exports = { SubscriptionUpdateRequest: SubscriptionUpdateRequest };

--- a/lib/v1/lib.js
+++ b/lib/v1/lib.js
@@ -4,6 +4,7 @@
 module.exports = {
   billingAgreements: require('./billingAgreements/lib'),
   billingPlans: require('./billingPlans/lib'),
+  billing: require('./billing/lib'),
   customerDisputes: require('./customerDisputes/lib'),
   identity: require('./identity/lib'),
   invoices: require('./invoices/lib'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paypal-rest-sdk",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "SDK for PayPal Rest APIs",
   "keywords": [
     "paypal",


### PR DESCRIPTION
Paypal has deprecated the Billing Agreements and Billing Plans API endpoints. Need to do something about that here too, but at the moment, this is only about getting the new beta release up to speed with the current release of the paypal api.

This PR adds the routes corresponding to documentation at paypal in the below link. I also did it somewhat haphazardly. Done so very intentionally to make sure the contributors here were aware of the changes and could take a better look at this. 

I now have to go back to trying not to starve. I'll be continually updating this fork of mine as I work through issues I (expect to) find. 

Please feel free to pull cherry pick my commit and do what ever you want with it. I wish I had more time to do a thorough job with this, but I just don't have the time. Figured I could write my own promises or try and help out over here.


TODO
* Tests
* Create the billing/plan files.