### PR TITLE
Send invoice method: added missed body data argument

### DIFF
--- a/lib/resources/Invoice.js
+++ b/lib/resources/Invoice.js
@@ -21,8 +21,8 @@ function invoice() {
         update: function update(id, data, config, cb) {
             api.executeHttp('PUT', this.baseURL + id, data, config, cb);
         },
-        send: function send(id, config, cb) {
-            api.executeHttp('POST', this.baseURL + id + '/send', {}, config, cb);
+        send: function send(id, data, config, cb) {
+            api.executeHttp('POST', this.baseURL + id + '/send', data, config, cb);
         },
         remind: function remind(id, data, config, cb) {
             api.executeHttp('POST', this.baseURL + id + '/remind', data, config, cb);


### PR DESCRIPTION
I've found that send invoice method missed data argument to pass into request body. It's small fix and It would be great if this pull request will be approved and merged.