### PR TITLE
adding paymentId to the same json as payer_id

### DIFF
--- a/samples/payment/execute.js
+++ b/samples/payment/execute.js
@@ -48,6 +48,7 @@ paypal.payment.create(create_payment_json, function (error, payment) {
 
 var execute_payment_json = {
     "payer_id": "Appended to redirect url",
+    "paymentId": "Appended to redirect url",
     "transactions": [{
         "amount": {
             "currency": "USD",
@@ -55,8 +56,6 @@ var execute_payment_json = {
         }
     }]
 };
-
-var paymentId = 'PAYMENT id created in previous step';
 
 paypal.payment.execute(paymentId, execute_payment_json, function (error, payment) {
     if (error) {


### PR DESCRIPTION
No need to separate the two, makes it less confusing.