### PR TITLE
passing sync mode is removed in samples,since it was deprecated

### DIFF
--- a/samples/payout/create_single_payout.js
+++ b/samples/payout/create_single_payout.js
@@ -31,9 +31,7 @@ var create_payout_json = {
     ]
 };
 
-var sync_mode = 'true';
-
-paypal.payout.create(create_payout_json, sync_mode, function (error, payout) {
+paypal.payout.create(create_payout_json, function (error, payout) {
     if (error) {
         console.log(error.response);
         throw error;


### PR DESCRIPTION
Removed sync_mode parameter from sample, for issue
https://github.com/paypal/PayPal-node-SDK/issues/399