### PR TITLE
Remove EOL node versions from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "4.0"
-  - "4.1"
+  - "10.20"
   - "stable"
 before_install:
   - npm install -g grunt-cli


### PR DESCRIPTION
Travis CI is failing for using old node versions that has reached EoL.
Currently supported stable node versions are 10.x and 12.x

I've removed the old node versions and added check for node version 10